### PR TITLE
IB: 0.2 part II

### DIFF
--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -475,6 +475,19 @@ void localtime_to_TIME(MYSQL_TIME *to, struct tm *from)
   to->second=   (int) from->tm_sec;
 }
 
+
+/*
+  Convert seconds since Epoch to TIME
+*/
+
+void unix_time_to_TIME(MYSQL_TIME *to, time_t secs, suseconds_t usecs)
+{
+  struct tm tm_time;
+  localtime_r(&secs, &tm_time);
+  localtime_to_TIME(to, &tm_time);
+  to->second_part = usecs;
+}
+
 void calc_time_from_sec(MYSQL_TIME *to, long seconds, long microseconds)
 {
   long t_seconds;

--- a/sql/sql_time.h
+++ b/sql/sql_time.h
@@ -171,6 +171,16 @@ bool calc_time_diff(const MYSQL_TIME *l_time1, const MYSQL_TIME *l_time2,
                     int lsign, MYSQL_TIME *l_time3, ulonglong fuzzydate);
 int my_time_compare(const MYSQL_TIME *a, const MYSQL_TIME *b);
 void localtime_to_TIME(MYSQL_TIME *to, struct tm *from);
+void unix_time_to_TIME(MYSQL_TIME *to, time_t secs, suseconds_t usecs);
+
+inline
+longlong unix_time_to_packed(time_t secs, suseconds_t usecs)
+{
+  MYSQL_TIME mysql_time;
+  unix_time_to_TIME(&mysql_time, secs, usecs);
+  return pack_time(&mysql_time);
+}
+
 void calc_time_from_sec(MYSQL_TIME *to, long seconds, long microseconds);
 uint calc_week(MYSQL_TIME *l_time, uint week_behaviour, uint *year);
 

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -243,7 +243,10 @@ dict_getnext_system_low(
 	rec_t*	rec = NULL;
 
 	while (!rec || rec_get_deleted_flag(rec, 0)) {
-		btr_pcur_move_to_next_user_rec(pcur, mtr);
+		if (pcur->search_mode == PAGE_CUR_L)
+			btr_pcur_move_to_prev_user_rec(pcur, mtr);
+		else
+			btr_pcur_move_to_next_user_rec(pcur, mtr);
 
 		rec = btr_pcur_get_rec(pcur);
 
@@ -271,7 +274,8 @@ dict_startscan_system(
 	btr_pcur_t*	pcur,		/*!< out: persistent cursor to
 					the record */
 	mtr_t*		mtr,		/*!< in: the mini-transaction */
-	dict_system_id_t system_id)	/*!< in: which system table to open */
+	dict_system_id_t system_id,	/*!< in: which system table to open */
+	bool		from_left)
 {
 	dict_table_t*	system_table;
 	dict_index_t*	clust_index;
@@ -283,7 +287,7 @@ dict_startscan_system(
 
 	clust_index = UT_LIST_GET_FIRST(system_table->indexes);
 
-	btr_pcur_open_at_index_side(true, clust_index, BTR_SEARCH_LEAF, pcur,
+	btr_pcur_open_at_index_side(from_left, clust_index, BTR_SEARCH_LEAF, pcur,
 				    true, 0, mtr);
 
 	rec = dict_getnext_system_low(pcur, mtr);
@@ -729,6 +733,15 @@ err_len:
 	return(NULL);
 }
 
+
+inline
+const char* dict_print_error(mem_heap_t* heap, ulint col, ulint len, ulint expected)
+{
+	return mem_heap_printf(heap,
+		"incorrect column %lu length in SYS_VTQ; got: %lu, expected: %lu",
+		col, len, expected);
+}
+
 /********************************************************************//**
 This function parses a SYS_VTQ record, extracts necessary
 information from the record and returns it to the caller.
@@ -739,13 +752,15 @@ dict_process_sys_vtq(
 /*=======================*/
 mem_heap_t*	heap,		/*!< in/out: heap memory */
 const rec_t*	rec,		/*!< in: current rec */
-ullong*		col_trx_id,	/*!< out: field values */
+trx_id_t*	col_trx_id,	/*!< out: field values */
 ullong*		col_begin_ts,
 ullong*		col_commit_ts,
-ullong*		col_concurr_trx)
+char**		col_concurr_trx)
 {
-	ulint		len;
-	const byte*	field;
+	ulint		len, col, concurr_n;
+	const byte	*field, *ptr;
+	char		*out;
+	trx_id_t	trx_id;
 
 	if (rec_get_deleted_flag(rec, 0)) {
 		return("delete-marked record in SYS_VTQ");
@@ -754,35 +769,57 @@ ullong*		col_concurr_trx)
 	if (rec_get_n_fields_old(rec) != DICT_NUM_FIELDS__SYS_VTQ) {
 		return("wrong number of columns in SYS_VTQ record");
 	}
-
+	/* TRX_ID */
 	field = rec_get_nth_field_old(
-		rec, DICT_FLD__SYS_VTQ__TRX_ID, &len);
-	if (len != sizeof(col_trx_id)) {
-	err_len:
-		return("incorrect column length in SYS_VTQ");
-	}
+		rec, (col = DICT_FLD__SYS_VTQ__TRX_ID), &len);
+
+	if (len != sizeof(trx_id_t))
+		return dict_print_error(heap, col, len, sizeof(trx_id_t));
+
 	*col_trx_id = mach_read_from_8(field);
-
+	/* BEGIN_TS */
 	field = rec_get_nth_field_old(
-		rec, DICT_FLD__SYS_VTQ__BEGIN_TS, &len);
-	if (len != sizeof(col_begin_ts)) {
-		goto err_len;
-	}
+		rec, (col = DICT_FLD__SYS_VTQ__BEGIN_TS), &len);
+
+	if (len != sizeof(ullong))
+		return dict_print_error(heap, col, len, sizeof(ullong));
+
 	*col_begin_ts = mach_read_from_8(field);
-
+	/* COMMIT_TS */
 	field = rec_get_nth_field_old(
-		rec, DICT_FLD__SYS_VTQ__COMMIT_TS, &len);
-	if (len != sizeof(col_commit_ts)) {
-		goto err_len;
-	}
+		rec, (col = DICT_FLD__SYS_VTQ__COMMIT_TS), &len);
+
+	if (len != sizeof(ullong))
+		return dict_print_error(heap, col, len, sizeof(ullong));
+
 	*col_commit_ts = mach_read_from_8(field);
-
+	/* CONCURR_TRX */
 	field = rec_get_nth_field_old(
-		rec, DICT_FLD__SYS_VTQ__CONCURR_TRX, &len);
-	if (len != sizeof(col_concurr_trx)) {
-		goto err_len;
+		rec, (col = DICT_FLD__SYS_VTQ__CONCURR_TRX), &len);
+	concurr_n = len / sizeof(trx_id_t);
+	if (len != concurr_n * sizeof(trx_id_t))
+		return dict_print_error(heap, col, len, concurr_n * sizeof(trx_id_t));
+
+	bool truncated = false;
+	if (concurr_n > I_S_MAX_CONCURR_TRX) {
+		concurr_n = I_S_MAX_CONCURR_TRX;
+		truncated = true;
 	}
-	*col_concurr_trx = mach_read_from_8(field);
+
+	if (concurr_n == 0) {
+		*col_concurr_trx = NULL;
+		return(NULL);
+	}
+	*col_concurr_trx = static_cast<char*>(mem_heap_alloc(heap, concurr_n * (TRX_ID_MAX_LEN + 1) + 3 + 1));
+	ptr = field, out = *col_concurr_trx;
+	for (ulint i = 0; i < concurr_n;
+		++i, ptr += sizeof(trx_id_t))
+	{
+		trx_id = mach_read_from_8(ptr);
+		out += ut_snprintf(out, TRX_ID_MAX_LEN + 1, TRX_ID_FMT " ", trx_id);
+	}
+	if (truncated)
+		strcpy(out, "...");
 
 	return(NULL);
 }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4274,6 +4274,11 @@ innobase_commit(
 
 	if (commit_trx
 	    || (!thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN))) {
+		/* Notify VTQ on System Versioned tables update */
+		if (trx->vtq_notify_on_commit) {
+			vers_notify_vtq(trx);
+			trx->vtq_notify_on_commit = false;
+		}
 
 		/* Run the fast part of commit if we did not already. */
 		if (!trx_is_active_commit_ordered(trx)) {

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -9221,10 +9221,11 @@ static ST_FIELD_INFO	innodb_vtq_fields_info[] =
 
 #define SYS_VTQ_CONCURR_TRX 3
 	{ STRUCT_FLD(field_name,	"concurr_trx"),
-	STRUCT_FLD(field_length,	120),
-	STRUCT_FLD(field_type,		MYSQL_TYPE_MEDIUM_BLOB),
+	// 3 for "..." if list is truncated
+	STRUCT_FLD(field_length,	I_S_MAX_CONCURR_TRX * (TRX_ID_MAX_LEN + 1) + 3),
+	STRUCT_FLD(field_type,		MYSQL_TYPE_STRING),
 	STRUCT_FLD(value,		0),
-	STRUCT_FLD(field_flags,		0),
+	STRUCT_FLD(field_flags,		MY_I_S_MAYBE_NULL),
 	STRUCT_FLD(old_name,		""),
 	STRUCT_FLD(open_method,		SKIP_OPEN_TABLE) },
 
@@ -9243,7 +9244,7 @@ i_s_dict_fill_vtq(
 	ullong		col_trx_id,	/*!< in: table fields */
 	ullong		col_begin_ts,
 	ullong		col_commit_ts,
-	ullong		col_concurr_trx,
+	char*		col_concurr_trx,
 	TABLE*		table_to_fill)	/*!< in/out: fill this table */
 {
 	Field**		fields;
@@ -9254,7 +9255,7 @@ i_s_dict_fill_vtq(
 	OK(field_store_ullong(fields[SYS_VTQ_TRX_ID], col_trx_id));
 	OK(field_store_packed_ts(fields[SYS_VTQ_BEGIN_TS], col_begin_ts));
 	OK(field_store_packed_ts(fields[SYS_VTQ_COMMIT_TS], col_commit_ts));
-	OK(field_store_ullong(fields[SYS_VTQ_CONCURR_TRX], col_concurr_trx));
+	OK(field_store_string(fields[SYS_VTQ_CONCURR_TRX], col_concurr_trx));
 
 	OK(schema_table_store_record(thd, table_to_fill));
 
@@ -9267,7 +9268,7 @@ Loop through each record in SYS_VTQ, and extract the column
 information and fill the INFORMATION_SCHEMA.INNODB_SYS_VTQ table.
 @return 0 on success */
 
-static const int I_S_SYS_VTQ_LIMIT = 1000; // maximum number of records in I_S.INNODB_SYS_VTQ
+static const int I_S_SYS_VTQ_LIMIT = 10000; // maximum number of records in I_S.INNODB_SYS_VTQ
 
 static
 int
@@ -9295,16 +9296,16 @@ i_s_sys_vtq_fill_table(
 	mutex_enter(&dict_sys->mutex);
 	mtr_start(&mtr);
 
-	rec = dict_startscan_system(&pcur, &mtr, SYS_VTQ);
+	rec = dict_startscan_system(&pcur, &mtr, SYS_VTQ, false);
 
 	for (int i = 0; rec && i < I_S_SYS_VTQ_LIMIT; ++i) {
 		const char*	err_msg;
-		ullong		col_trx_id;
+		trx_id_t	col_trx_id;
 		ullong		col_begin_ts;
 		ullong		col_commit_ts;
-		ullong		col_concurr_trx;
+		char*		col_concurr_trx;
 
-		/* Extract necessary information from a SYS_VTQ row */
+		/* Extract necessary information from SYS_VTQ row */
 		err_msg = dict_process_sys_vtq(
 			heap,
 			rec,

--- a/storage/innobase/include/btr0pcur.h
+++ b/storage/innobase/include/btr0pcur.h
@@ -328,6 +328,17 @@ btr_pcur_move_to_next_user_rec(
 				function may release the page latch */
 	mtr_t*		mtr);	/*!< in: mtr */
 /*********************************************************//**
+Moves the persistent cursor to the previous user record in the tree. If no user
+records are left, the cursor ends up 'before first in tree'.
+@return	TRUE if the cursor moved forward, ending on a user record */
+UNIV_INLINE
+ibool
+btr_pcur_move_to_prev_user_rec(
+/*===========================*/
+	btr_pcur_t*	cursor,	/*!< in: persistent cursor; NOTE that the
+				function may release the page latch */
+	mtr_t*		mtr);	/*!< in: mtr */
+/*********************************************************//**
 Moves the persistent cursor to the first record on the next page.
 Releases the latch on the current page, and bufferunfixes it.
 Note that there must not be modifications on the current page,
@@ -335,6 +346,18 @@ as then the x-latch can be released only in mtr_commit. */
 UNIV_INTERN
 void
 btr_pcur_move_to_next_page(
+/*=======================*/
+	btr_pcur_t*	cursor,	/*!< in: persistent cursor; must be on the
+				last record of the current page */
+	mtr_t*		mtr);	/*!< in: mtr */
+/*********************************************************//**
+Moves the persistent cursor to the last record on the previous page.
+Releases the latch on the current page, and bufferunfixes it.
+Note that there must not be modifications on the current page,
+as then the x-latch can be released only in mtr_commit. */
+UNIV_INTERN
+void
+btr_pcur_move_to_prev_page(
 /*=======================*/
 	btr_pcur_t*	cursor,	/*!< in: persistent cursor; must be on the
 				last record of the current page */

--- a/storage/innobase/include/btr0pcur.ic
+++ b/storage/innobase/include/btr0pcur.ic
@@ -334,6 +334,42 @@ loop:
 }
 
 /*********************************************************//**
+Moves the persistent cursor to the previous user record in the tree. If no user
+records are left, the cursor ends up 'before first in tree'.
+@return	TRUE if the cursor moved forward, ending on a user record */
+UNIV_INLINE
+ibool
+btr_pcur_move_to_prev_user_rec(
+/*===========================*/
+	btr_pcur_t*	cursor,	/*!< in: persistent cursor; NOTE that the
+				function may release the page latch */
+	mtr_t*		mtr)	/*!< in: mtr */
+{
+	ut_ad(cursor->pos_state == BTR_PCUR_IS_POSITIONED);
+	ut_ad(cursor->latch_mode != BTR_NO_LATCHES);
+	cursor->old_stored = BTR_PCUR_OLD_NOT_STORED;
+loop:
+	if (btr_pcur_is_before_first_on_page(cursor)) {
+
+		if (btr_pcur_is_before_first_in_tree(cursor, mtr)) {
+
+			return(FALSE);
+		}
+
+		btr_pcur_move_to_prev(cursor, mtr);
+	} else {
+		btr_pcur_move_to_prev_on_page(cursor);
+	}
+
+	if (btr_pcur_is_on_user_rec(cursor)) {
+
+		return(TRUE);
+	}
+
+	goto loop;
+}
+
+/*********************************************************//**
 Moves the persistent cursor to the next record in the tree. If no records are
 left, the cursor stays 'after last in tree'.
 @return	TRUE if the cursor was not after last in tree */

--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -263,7 +263,8 @@ dict_startscan_system(
 	btr_pcur_t*	pcur,		/*!< out: persistent cursor to
 					the record */
 	mtr_t*		mtr,		/*!< in: the mini-transaction */
-	dict_system_id_t system_id);	/*!< in: which system table to open */
+	dict_system_id_t system_id,	/*!< in: which system table to open */
+	bool		from_left = true);
 /********************************************************************//**
 This function get the next system table record as we scan the table.
 @return	the record if found, NULL if end of scan. */
@@ -391,6 +392,7 @@ dict_process_sys_datafiles(
 This function parses a SYS_VTQ record, extracts necessary
 information from the record and returns it to the caller.
 @return error message, or NULL on success */
+#define I_S_MAX_CONCURR_TRX 100
 UNIV_INTERN
 const char*
 dict_process_sys_vtq(
@@ -400,7 +402,7 @@ const rec_t*	rec,		/*!< in: current rec */
 ullong*		col_trx_id,	/*!< out: field values */
 ullong*		col_begin_ts,
 ullong*		col_commit_ts,
-ullong*		col_concurr_trx);
+char**		col_concurr_trx);
 /********************************************************************//**
 Get the filepath for a spaceid from SYS_DATAFILES. This function provides
 a temporary heap which is used for the table lookup, but not for the path.

--- a/storage/innobase/include/row0ins.h
+++ b/storage/innobase/include/row0ins.h
@@ -97,8 +97,9 @@ row_ins_clust_index_entry_low(
 	ulint		n_uniq,	/*!< in: 0 or index->n_uniq */
 	dtuple_t*	entry,	/*!< in/out: index entry to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
-	que_thr_t*	thr)	/*!< in: query thread or NULL */
-	__attribute__((nonnull, warn_unused_result));
+	que_thr_t*	thr,	/*!< in: query thread or NULL */
+	trx_t*		trx = 0)
+	__attribute__((warn_unused_result));
 /***************************************************************//**
 Tries to insert an entry into a secondary index. If a record with exactly the
 same fields is found, the other record is necessarily marked deleted.
@@ -122,8 +123,9 @@ row_ins_sec_index_entry_low(
 	dtuple_t*	entry,	/*!< in/out: index entry to insert */
 	trx_id_t	trx_id,	/*!< in: PAGE_MAX_TRX_ID during
 				row_log_table_apply(), or 0 */
-	que_thr_t*	thr)	/*!< in: query thread */
-	__attribute__((nonnull, warn_unused_result));
+	que_thr_t*	thr,	/*!< in: query thread */
+	trx_t*		trx = 0)
+	__attribute__((warn_unused_result));
 /***************************************************************//**
 Tries to insert the externally stored fields (off-page columns)
 of a clustered index entry.
@@ -192,7 +194,7 @@ row_ins_step(
 /***********************************************************//**
 Inserts a row to SYS_VTQ table.
 @return	error state */
-dberr_t vers_notify_vtq(que_thr_t * thr, mem_heap_t * heap);
+void vers_notify_vtq(trx_t* trx);
 
 /* Insert node structure */
 

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1031,7 +1031,7 @@ struct trx_t{
 	os_event_t	wsrep_event;	/* event waited for in srv_conc_slot */
 #endif /* WITH_WSREP */
 
-	bool vtq_notified;
+	bool vtq_notify_on_commit;	/*!< Notify VTQ for System Versioned update */
 };
 
 /* Transaction isolation levels (trx->isolation_level) */

--- a/storage/innobase/include/trx0types.h
+++ b/storage/innobase/include/trx0types.h
@@ -125,6 +125,7 @@ typedef ib_id_t	undo_no_t;
 /** Transaction savepoint */
 struct trx_savept_t{
 	undo_no_t	least_undo_no;	/*!< least undo number to undo */
+	bool		vtq_notify_on_commit; /*!< Notify VTQ for System Versioned update */
 };
 
 /** File objects */

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -52,6 +52,7 @@ Created 4/20/1996 Heikki Tuuri
 #include "fts0fts.h"
 #include "fts0types.h"
 #include "m_string.h"
+#include "sql_time.h"
 
 /*************************************************************************
 IMPORTANT NOTE: Any operation that generates redo MUST check that there
@@ -1935,7 +1936,8 @@ row_ins_scan_sec_index_for_duplicate(
 	que_thr_t*	thr,	/*!< in: query thread */
 	bool		s_latch,/*!< in: whether index->lock is being held */
 	mtr_t*		mtr,	/*!< in/out: mini-transaction */
-	mem_heap_t*	offsets_heap)
+	mem_heap_t*	offsets_heap,
+	trx_t*		trx = 0)
 				/*!< in/out: memory heap that can be emptied */
 {
 	ulint		n_unique;
@@ -1945,6 +1947,10 @@ row_ins_scan_sec_index_for_duplicate(
 	dberr_t		err		= DB_SUCCESS;
 	ulint		allow_duplicates;
 	ulint*		offsets		= NULL;
+
+	ut_ad(thr || (trx && flags & BTR_NO_LOCKING_FLAG));
+	if (!trx)
+		trx = thr_get_trx(thr);
 
 #ifdef UNIV_SYNC_DEBUG
 	ut_ad(s_latch == rw_lock_own(&index->lock, RW_LOCK_SHARED));
@@ -1976,7 +1982,7 @@ row_ins_scan_sec_index_for_duplicate(
 		      : BTR_SEARCH_LEAF,
 		      &pcur, mtr);
 
-	allow_duplicates = thr_get_trx(thr)->duplicates;
+	allow_duplicates = trx->duplicates;
 
 	/* Scan index records and check if there is a duplicate */
 
@@ -2032,7 +2038,7 @@ row_ins_scan_sec_index_for_duplicate(
 							index, offsets)) {
 				err = DB_DUPLICATE_KEY;
 
-				thr_get_trx(thr)->error_info = index;
+				trx->error_info = index;
 
 				/* If the duplicate is on hidden FTS_DOC_ID,
 				state so in the error log */
@@ -2344,7 +2350,8 @@ row_ins_clust_index_entry_low(
 	ulint		n_uniq,	/*!< in: 0 or index->n_uniq */
 	dtuple_t*	entry,	/*!< in/out: index entry to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
-	que_thr_t*	thr)	/*!< in: query thread */
+	que_thr_t*	thr,	/*!< in: query thread */
+	trx_t*		trx)
 {
 	btr_cur_t	cursor;
 	ulint*		offsets		= NULL;
@@ -2353,12 +2360,16 @@ row_ins_clust_index_entry_low(
 	mtr_t		mtr;
 	mem_heap_t*	offsets_heap	= NULL;
 
+	ut_ad(thr || trx);
+	if (!trx)
+		trx = thr_get_trx(thr);
+
 	ut_ad(dict_index_is_clust(index));
 	ut_ad(!dict_index_is_unique(index)
 	      || n_uniq == dict_index_get_n_unique(index));
 	ut_ad(!n_uniq || n_uniq == dict_index_get_n_unique(index));
 
-	mtr_start_trx(&mtr, thr_get_trx(thr));
+	mtr_start_trx(&mtr, trx);
 
 	if (mode == BTR_MODIFY_LEAF && dict_index_is_online_ddl(index)) {
 		mode = BTR_MODIFY_LEAF | BTR_ALREADY_S_LATCHED;
@@ -2398,7 +2409,10 @@ row_ins_clust_index_entry_low(
 
 		if (flags
 		    == (BTR_CREATE_FLAG | BTR_NO_LOCKING_FLAG
-			| BTR_NO_UNDO_LOG_FLAG | BTR_KEEP_SYS_FLAG)) {
+			| BTR_NO_UNDO_LOG_FLAG | BTR_KEEP_SYS_FLAG) || !thr) {
+			// thr == 0 for SYS_VTQ table
+			ut_ad(thr || flags &
+				(BTR_NO_LOCKING_FLAG | BTR_NO_UNDO_LOG_FLAG | BTR_KEEP_SYS_FLAG));
 			/* Set no locks when applying log
 			in online table rebuild. Only check for duplicates. */
 			err = row_ins_duplicate_error_in_clust_online(
@@ -2413,7 +2427,7 @@ row_ins_clust_index_entry_low(
 				/* fall through */
 			case DB_SUCCESS_LOCKED_REC:
 			case DB_DUPLICATE_KEY:
-				thr_get_trx(thr)->error_info = cursor.index;
+				trx->error_info = cursor.index;
 			}
 		} else {
 			/* Note that the following may return also
@@ -2469,14 +2483,14 @@ err_exit:
 			truncated in the crash. */
 
 			DEBUG_SYNC_C_IF_THD(
-				thr_get_trx(thr)->mysql_thd,
+				trx->mysql_thd,
 				"before_row_ins_upd_extern");
 			err = btr_store_big_rec_extern_fields(
 				index, btr_cur_get_block(&cursor),
 				rec, offsets, big_rec, &mtr,
 				BTR_STORE_INSERT_UPDATE);
 			DEBUG_SYNC_C_IF_THD(
-				thr_get_trx(thr)->mysql_thd,
+				trx->mysql_thd,
 				"after_row_ins_upd_extern");
 			/* If writing big_rec fails (for
 			example, because of DB_OUT_OF_FILE_SPACE),
@@ -2551,7 +2565,7 @@ err_exit:
 					LSN_MAX, TRUE););
 			err = row_ins_index_entry_big_rec(
 				entry, big_rec, offsets, &offsets_heap, index,
-				thr_get_trx(thr)->mysql_thd,
+				trx->mysql_thd,
 				__FILE__, __LINE__);
 			dtuple_convert_back_big_rec(index, entry, big_rec);
 		} else {
@@ -2639,7 +2653,8 @@ row_ins_sec_index_entry_low(
 	dtuple_t*	entry,	/*!< in/out: index entry to insert */
 	trx_id_t	trx_id,	/*!< in: PAGE_MAX_TRX_ID during
 				row_log_table_apply(), or 0 */
-	que_thr_t*	thr)	/*!< in: query thread */
+	que_thr_t*	thr,	/*!< in: query thread */
+	trx_t*		trx)
 {
 	btr_cur_t	cursor;
 	ulint		search_mode	= mode | BTR_INSERT;
@@ -2647,13 +2662,16 @@ row_ins_sec_index_entry_low(
 	ulint		n_unique;
 	mtr_t		mtr;
 	ulint*		offsets	= NULL;
-	trx_t*		trx = thr_get_trx(thr);
+
+	ut_ad(thr || trx);
+	if (!trx)
+		trx = thr_get_trx(thr);
 
 	ut_ad(!dict_index_is_clust(index));
 	ut_ad(mode == BTR_MODIFY_LEAF || mode == BTR_MODIFY_TREE);
 
 	cursor.thr = thr;
-	ut_ad(thr_get_trx(thr)->id);
+	ut_ad(trx->id);
 	mtr_start_trx(&mtr, trx);
 
 	/* Ensure that we acquire index->lock when inserting into an
@@ -2673,7 +2691,7 @@ row_ins_sec_index_entry_low(
 		}
 
 		if (row_log_online_op_try(
-			    index, entry, thr_get_trx(thr)->id)) {
+			    index, entry, trx->id)) {
 			goto func_exit;
 		}
 	}
@@ -2682,7 +2700,7 @@ row_ins_sec_index_entry_low(
 	the function will return in both low_match and up_match of the
 	cursor sensible values */
 
-	if (!thr_get_trx(thr)->check_unique_secondary) {
+	if (!trx->check_unique_secondary) {
 		search_mode |= BTR_IGNORE_SEC_UNIQUE;
 	}
 
@@ -2734,7 +2752,7 @@ row_ins_sec_index_entry_low(
 		}
 
 		err = row_ins_scan_sec_index_for_duplicate(
-			flags, index, entry, thr, check, &mtr, offsets_heap);
+			flags, index, entry, thr, check, &mtr, offsets_heap, trx);
 
 		mtr_commit(&mtr);
 
@@ -2743,7 +2761,7 @@ row_ins_sec_index_entry_low(
 			break;
 		case DB_DUPLICATE_KEY:
 			if (*index->name == TEMP_INDEX_PREFIX) {
-				ut_ad(!thr_get_trx(thr)
+				ut_ad(!trx
 				      ->dict_operation_lock_mode);
 				mutex_enter(&dict_sys->mutex);
 				dict_set_corrupted_index_cache_only(
@@ -3391,63 +3409,134 @@ error_handling:
 inline
 void set_row_field_8(dtuple_t* row, int field_num, ib_uint64_t data, mem_heap_t* heap)
 {
+	static const ulint fsize = 8;
 	dfield_t* dfield = dtuple_get_nth_field(row, field_num);
-	byte* buf = static_cast<byte*>(mem_heap_alloc(heap, 8));
+	ut_ad(dfield->type.len == fsize);
+	byte* buf = static_cast<byte*>(mem_heap_alloc(heap, fsize));
 	mach_write_to_8(buf, data);
-	dfield_set_data(dfield, buf, 8);
+	dfield_set_data(dfield, buf, fsize);
 }
 
-#include "my_time.h"
-#include "sql_time.h"
+/***********************************************************//**
+Inserts a row to SYS_VTQ, low level.
+@return DB_SUCCESS if operation successfully completed, else error
+code */
+static __attribute__((nonnull, warn_unused_result))
+dberr_t
+vers_row_ins_vtq_low(trx_t* trx, mem_heap_t* heap, dtuple_t* row)
+{
+	dberr_t		err;
+	dtuple_t*	entry;
+	ulint		n_index = 0;
+	dict_index_t*	index	= dict_table_get_first_index(dict_sys->sys_vtq);
+	static const ulint flags
+		= (BTR_KEEP_SYS_FLAG
+			| BTR_NO_LOCKING_FLAG
+			| BTR_NO_UNDO_LOG_FLAG);
+
+	entry = row_build_index_entry(row, NULL, index, heap);
+
+	dfield_t* dfield = dtuple_get_nth_field(entry, DATA_TRX_ID);
+	ut_ad(dfield->type.len == DATA_TRX_ID_LEN);
+	dfield_set_data(dfield, mem_heap_alloc(heap, DATA_TRX_ID_LEN), DATA_TRX_ID_LEN);
+	row_upd_index_entry_sys_field(entry, index, DATA_TRX_ID, trx->id);
+
+	err = row_ins_clust_index_entry_low(
+		flags, BTR_MODIFY_TREE, index, index->n_uniq, entry, 0, NULL, trx);
+
+	switch (err) {
+	case DB_SUCCESS:
+		break;
+	case DB_SUCCESS_LOCKED_REC:
+		/* The row had already been copied to the table. */
+		fprintf(stderr, "InnoDB: duplicate VTQ record!\n");
+		return DB_SUCCESS;
+	default:
+		return err;
+	}
+
+	mem_heap_t* offsets_heap = mem_heap_create(1024);
+
+	do {
+		n_index++;
+
+		if (!(index = dict_table_get_next_index(index))) {
+			break;
+		}
+
+		if (index->type & DICT_FTS) {
+			continue;
+		}
+
+		entry = row_build_index_entry(row, NULL, index, heap);
+		err = row_ins_sec_index_entry_low(
+			flags, BTR_MODIFY_TREE,
+			index, offsets_heap, heap, entry, trx->id, NULL, trx);
+
+		///* Report correct index name for duplicate key error. */
+		// No need to report on commit phase?
+		//if (err == DB_DUPLICATE_KEY) {
+		//	trx->error_key_num = n_index;
+		//}
+	} while (err == DB_SUCCESS);
+
+	mem_heap_free(offsets_heap);
+	return err;
+}
 
 /***********************************************************//**
 Inserts a row to SYS_VTQ table.
 @return	error state */
-UNIV_INTERN
-dberr_t
-vers_notify_vtq(que_thr_t* thr, mem_heap_t* heap)
+void vers_notify_vtq(trx_t* trx)
 {
-	dberr_t		err;
-	trx_t*		trx = thr_get_trx(thr);
-	dict_table_t*	sys_vtq = dict_sys->sys_vtq;
-	ins_node_t*	node = ins_node_create(INS_DIRECT, sys_vtq, heap);
+	dberr_t err;
+	mem_heap_t* heap = mem_heap_create(1024);
+	dtuple_t* row = dtuple_create(heap, dict_table_get_n_cols(dict_sys->sys_vtq));
 
-	node->select = NULL;
-	node->values_list = NULL; // for INS_VALUES
+	ulint now_secs, now_usecs;
+	ut_usectime(&now_secs, &now_usecs);
+	ullong begin_ts = unix_time_to_packed(trx->start_time, trx->start_time_us);
+	ullong commit_ts = unix_time_to_packed(now_secs, now_usecs);
 
-	dtuple_t* row = dtuple_create(heap, dict_table_get_n_cols(sys_vtq));
-	dict_table_copy_types(row, sys_vtq);
-
-	struct tm unix_time;
-	MYSQL_TIME mysql_time;
-	localtime_r(&trx->start_time, &unix_time);
-	localtime_to_TIME(&mysql_time, &unix_time);
-	mysql_time.second_part = trx->start_time_us;
-	ullong start_time = pack_time(&mysql_time);
-
+	dict_table_copy_types(row, dict_sys->sys_vtq);
 	set_row_field_8(row, DICT_FLD__SYS_VTQ__TRX_ID, trx->id, heap);
-	set_row_field_8(row, DICT_FLD__SYS_VTQ__BEGIN_TS - 2, start_time, heap);
-	set_row_field_8(row, DICT_FLD__SYS_VTQ__COMMIT_TS - 2, start_time, heap);
-	set_row_field_8(row, DICT_FLD__SYS_VTQ__CONCURR_TRX - 2, 3, heap);
+	set_row_field_8(row, DICT_FLD__SYS_VTQ__BEGIN_TS - 2, begin_ts, heap);
+	set_row_field_8(row, DICT_FLD__SYS_VTQ__COMMIT_TS - 2, commit_ts, heap);
 
-	ins_node_set_new_row(node, row);
+	dfield_t* dfield = dtuple_get_nth_field(row, DICT_FLD__SYS_VTQ__CONCURR_TRX - 2);
+	mutex_enter(&trx_sys->mutex);
+	trx_list_t &rw_list = trx_sys->rw_trx_list;
+	if (rw_list.count > 1) {
+		byte* buf = static_cast<byte*>(mem_heap_alloc(heap, rw_list.count * 8));
+		byte* ptr = buf;
+		ulint count = 0;
 
-	trx_write_trx_id(node->trx_id_buf, trx->id);
-	err = lock_table(0, node->table, LOCK_IX, thr);
-	DBUG_EXECUTE_IF("ib_row_ins_ix_lock_wait",
-		err = DB_LOCK_WAIT;);
+		for (trx_t* ctrx = UT_LIST_GET_FIRST(rw_list);
+			ctrx != NULL;
+			ctrx = UT_LIST_GET_NEXT(trx_list, ctrx))
+		{
+			if (ctrx == trx || ctrx->state == TRX_STATE_NOT_STARTED)
+				continue;
 
-	if (err != DB_SUCCESS) {
-		goto end_func;
+			mach_write_to_8(ptr, ctrx->id);
+			++count;
+			ptr += 8;
+		}
+
+		if (count)
+			dfield_set_data(dfield, buf, count * 8);
+		else
+			dfield_set_data(dfield, NULL, 0);
+	} else {
+		// there must be at least current transaction
+		ut_ad(rw_list.count == 1 && UT_LIST_GET_FIRST(rw_list) == trx);
+		dfield_set_data(dfield, NULL, 0);
 	}
+	mutex_exit(&trx_sys->mutex);
 
-	node->trx_id = trx->id;
-	node->state = INS_NODE_ALLOC_ROW_ID;
-	err = row_ins(node, thr);
+	err = vers_row_ins_vtq_low(trx, heap, row);
+	if (DB_SUCCESS != err)
+		fprintf(stderr, "InnoDB: failed to insert VTQ record (error %d)\n", err);
 
-end_func:
-	trx->error_state = err;
-	if (err != DB_SUCCESS)
-		fprintf(stderr, "InnoDB: failed to insert VTQ record (see SQL error message)\n");
-	return err;
+	mem_heap_free(heap);
 }

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1400,12 +1400,8 @@ error_exit:
 		return(err);
 	}
 
-	if (!trx->vtq_notified && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
-		trx->vtq_notified = true;
-		err = vers_notify_vtq(thr, node->table->heap);
-		if (err != DB_SUCCESS) {
-			goto error_exit;
-		}
+	if (!trx->vtq_notify_on_commit && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
+		trx->vtq_notify_on_commit = true;
 	}
 
 	if (dict_table_has_fts_index(table)) {
@@ -1821,7 +1817,6 @@ run_again:
 	thr->fk_cascade_depth = 0;
 
 	if (err != DB_SUCCESS) {
-	error_exit:
 		que_thr_stop_for_mysql(thr);
 
 		if (err == DB_RECORD_NOT_FOUND) {
@@ -1848,12 +1843,8 @@ run_again:
 		return(err);
 	}
 
-	if (!trx->vtq_notified && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
-		trx->vtq_notified = true;
-		err = vers_notify_vtq(thr, node->table->heap);
-		if (err != DB_SUCCESS) {
-			goto error_exit;
-		}
+	if (!trx->vtq_notify_on_commit && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
+		trx->vtq_notify_on_commit = true;
 	}
 
 	que_thr_stop_for_mysql_no_error(thr, trx);
@@ -2110,12 +2101,8 @@ run_again:
 		return(err);
 	}
 
-	if (!trx->vtq_notified && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
-		trx->vtq_notified = true;
-		err = vers_notify_vtq(thr, node->table->heap);
-		if (err != DB_SUCCESS) {
-			return err;
-		}
+	if (!trx->vtq_notify_on_commit && DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
+		trx->vtq_notify_on_commit = true;
 	}
 
 	if (node->is_delete) {

--- a/storage/innobase/trx/trx0roll.cc
+++ b/storage/innobase/trx/trx0roll.cc
@@ -122,6 +122,7 @@ trx_rollback_to_savepoint_low(
 	} else {
 		trx->lock.que_state = TRX_QUE_RUNNING;
 		MONITOR_INC(MONITOR_TRX_ROLLBACK_SAVEPOINT);
+		trx->vtq_notify_on_commit = savept->vtq_notify_on_commit;
 	}
 
 	ut_a(trx->error_state == DB_SUCCESS);
@@ -533,6 +534,7 @@ trx_savept_take(
 	trx_savept_t	savept;
 
 	savept.least_undo_no = trx->undo_no;
+	savept.vtq_notify_on_commit = trx->vtq_notify_on_commit;
 
 	return(savept);
 }

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -164,6 +164,8 @@ trx_create(void)
 	trx->lock.table_locks = ib_vector_create(
 		heap_alloc, sizeof(void**), 32);
 
+	trx->vtq_notify_on_commit = false;
+
 #ifdef WITH_WSREP
 	trx->wsrep_event = NULL;
 #endif /* WITH_WSREP */
@@ -917,7 +919,7 @@ trx_start_low(
 
 	mutex_exit(&trx_sys->mutex);
 
-	trx->vtq_notified = false;
+	trx->vtq_notify_on_commit = false;
 	ut_usectime(
 		(ulint*)&trx->start_time,
 		(ulint*)&trx->start_time_us);


### PR DESCRIPTION
- moved vers_notify_vtq() to commit phase;
- low_level insert (load test passed);
- rest of SYS_VTQ columns filled: COMMIT_TS, CONCURR_TRX;
- savepoints support;
- I_S.INNODB_SYS_VTQ adjustments:
  - limit to I_S_SYS_VTQ_LIMIT(10000) of most recent records;
  - CONCURR_TRX limit to I_S_MAX_CONCURR_TRX(100) with '...' truncation marker;
  - TIMESTAMP fields show fractions of seconds.

Resolves #8, fixes #25
