### PR TITLE
Moved goto to inner block to make clang 8.0 happy.

### DIFF
--- a/storage/maria/ma_sort.c
+++ b/storage/maria/ma_sort.c
@@ -379,12 +379,15 @@ pthread_handler_t _ma_thr_find_all_keys(void *arg)
 
   error=1;
 
-  if (my_thread_init())
-    goto err;
+  const int mti = my_thread_init();
 
   { /* Add extra block since DBUG_ENTER declare variables */
     DBUG_ENTER("_ma_thr_find_all_keys");
     DBUG_PRINT("enter", ("master: %d", sort_param->master));
+
+    if (mti)
+      goto err;
+
     if (sort_param->sort_info->got_error)
       goto err;
 

--- a/storage/myisam/sort.c
+++ b/storage/myisam/sort.c
@@ -358,12 +358,15 @@ pthread_handler_t thr_find_all_keys(void *arg)
 
   error=1;
 
-  if (my_thread_init())
-    goto err;
+  const int mti = my_thread_init();
 
   { /* Add extra block since DBUG_ENTER declare variables */
     DBUG_ENTER("thr_find_all_keys");
     DBUG_PRINT("enter", ("master: %d", sort_param->master));
+
+    if (mti)
+      goto err;
+
     if (sort_param->sort_info->got_error)
       goto err;
 


### PR DESCRIPTION
Without these changes , compilation with clang 8.0.0 under mac finishes with error:

```
note: jump bypasses initialization of variable with __attribute__((cleanup))
```
