### PR TITLE
IB: 0.2 part IV

### DIFF
--- a/mysql-test/r/delete.result
+++ b/mysql-test/r/delete.result
@@ -525,110 +525,56 @@ ERROR HY000: Can not delete from join view 'test.v2'
 DROP VIEW v2, v1;
 DROP TABLE t1, t2;
 #
-# Test for SYSTEM VERSIONING
+# System Versioning Support
 #
-SET @@session.time_zone='+00:00';
-create table t1 (
-XNo INT UNSIGNED,
-Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
-Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
-PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)
-) WITH SYSTEM VERSIONING;
-INSERT INTO t1(XNo) VALUES(0);
-INSERT INTO t1(XNo) VALUES(1);
-INSERT INTO t1(XNo) VALUES(2);
-INSERT INTO t1(XNo) VALUES(3);
-INSERT INTO t1(XNo) VALUES(4);
-INSERT INTO t1(XNo) VALUES(5);
-INSERT INTO t1(XNo) VALUES(6);
-INSERT INTO t1(XNo) VALUES(7);
-INSERT INTO t1(XNo) VALUES(8);
-INSERT INTO t1(XNo) VALUES(9);
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
-0	0
-1	0
-2	0
-3	0
-4	0
-5	0
-6	0
-7	0
-8	0
-9	0
-DELETE FROM t1 WHERE XNo = 0;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
-0	1
-1	0
-2	0
-3	0
-4	0
-5	0
-6	0
-7	0
-8	0
-9	0
-DELETE FROM t1 WHERE XNo = 1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
-0	1
-1	1
-2	0
-3	0
-4	0
-5	0
-6	0
-7	0
-8	0
-9	0
-DELETE FROM t1 WHERE XNo > 5;
-CREATE VIEW vt1 AS SELECT XNo FROM t1;
-SELECT XNo FROM vt1;
-XNo
-2
-3
-4
-5
-DELETE FROM vt1 WHERE XNo = 3;
-SELECT XNo FROM vt1;
-XNo
-2
-4
-5
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
-0	1
-1	1
-2	0
-3	1
-4	0
-5	0
-6	1
-7	1
-8	1
-9	1
-DROP VIEW vt1;
-DROP TABLE t1;
+#
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-create table t1 (
-XNo INT UNSIGNED,
-Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
-Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
-PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)
-) WITH SYSTEM VERSIONING ENGINE InnoDB;
-INSERT INTO t1(XNo) VALUES(0);
-INSERT INTO t1(XNo) VALUES(1);
-INSERT INTO t1(XNo) VALUES(2);
-INSERT INTO t1(XNo) VALUES(3);
-INSERT INTO t1(XNo) VALUES(4);
-INSERT INTO t1(XNo) VALUES(5);
-INSERT INTO t1(XNo) VALUES(6);
-INSERT INTO t1(XNo) VALUES(7);
-INSERT INTO t1(XNo) VALUES(8);
-INSERT INTO t1(XNo) VALUES(9);
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    XNo int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+insert into t1(XNo) values(0);
+insert into t1(XNo) values(1);
+insert into t1(XNo) values(2);
+insert into t1(XNo) values(3);
+insert into t1(XNo) values(4);
+insert into t1(XNo) values(5);
+insert into t1(XNo) values(6);
+insert into t1(XNo) values(7);
+insert into t1(XNo) values(8);
+insert into t1(XNo) values(9);
+set @str= concat('select XNo, ',
+fields, " < '2038-01-19 03:14:07'
+  from t1 for system_time
+  between timestamp '0000-0-0 0:0:0'
+  and timestamp '2038-01-19 04:14:07'");
+prepare stmt from @str; execute stmt;
+delete from t1 where XNo = 0;
+execute stmt;
+delete from t1 where XNo = 1;
+execute stmt;
+delete from t1 where XNo > 5;
+create view vt1 as select XNo from t1;
+select XNo from vt1;
+delete from vt1 where XNo = 3;
+select XNo from vt1;
+execute stmt; drop prepare stmt;
+drop view vt1;
+drop table t1;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+XNo	sys_end < '2038-01-19 03:14:07'
 0	0
 1	0
 2	0
@@ -639,9 +585,7 @@ XNo	Sys_end < '2038-01-19 03:14:07'
 7	0
 8	0
 9	0
-DELETE FROM t1 WHERE XNo = 0;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
+XNo	sys_end < '2038-01-19 03:14:07'
 0	1
 1	0
 2	0
@@ -652,9 +596,7 @@ XNo	Sys_end < '2038-01-19 03:14:07'
 7	0
 8	0
 9	0
-DELETE FROM t1 WHERE XNo = 1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
+XNo	sys_end < '2038-01-19 03:14:07'
 0	1
 1	1
 2	0
@@ -665,22 +607,16 @@ XNo	Sys_end < '2038-01-19 03:14:07'
 7	0
 8	0
 9	0
-DELETE FROM t1 WHERE XNo > 5;
-CREATE VIEW vt1 AS SELECT XNo FROM t1;
-SELECT XNo FROM vt1;
 XNo
 2
 3
 4
 5
-DELETE FROM vt1 WHERE XNo = 3;
-SELECT XNo FROM vt1;
 XNo
 2
 4
 5
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-XNo	Sys_end < '2038-01-19 03:14:07'
+XNo	sys_end < '2038-01-19 03:14:07'
 0	1
 1	1
 2	0
@@ -691,10 +627,77 @@ XNo	Sys_end < '2038-01-19 03:14:07'
 7	1
 8	1
 9	1
-DROP VIEW vt1;
-DROP TABLE t1;
-SET @i = 0;
-SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+XNo	commit_ts(sys_end) < '2038-01-19 03:14:07'
+0	0
+1	0
+2	0
+3	0
+4	0
+5	0
+6	0
+7	0
+8	0
+9	0
+XNo	commit_ts(sys_end) < '2038-01-19 03:14:07'
+0	1
+1	0
+2	0
+3	0
+4	0
+5	0
+6	0
+7	0
+8	0
+9	0
+XNo	commit_ts(sys_end) < '2038-01-19 03:14:07'
+0	1
+1	1
+2	0
+3	0
+4	0
+5	0
+6	0
+7	0
+8	0
+9	0
+XNo
+2
+3
+4
+5
+XNo
+2
+4
+5
+XNo	commit_ts(sys_end) < '2038-01-19 03:14:07'
+0	1
+1	1
+2	0
+3	1
+4	0
+5	0
+6	1
+7	1
+8	1
+9	1
+drop procedure test_01;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1
 2	1	1	1	1
@@ -710,3 +713,4 @@ No	A	B	C	D
 12	1	1	1	1
 13	1	1	1	1
 14	1	1	1	1
+drop procedure verify_vtq;

--- a/mysql-test/r/insert.result
+++ b/mysql-test/r/insert.result
@@ -721,114 +721,165 @@ DROP TABLE t1;
 # System Versioning Support
 #
 #
-SET @@session.time_zone='+00:00';
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES(3, 4);
-INSERT INTO t1(x, y) VALUES(2, 3);
-INSERT INTO t1 VALUES(40, 33);
-SELECT x, y, Sys_end FROM t1;
-x	y	Sys_end
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+insert into t1(x, y) values(3, 4);
+insert into t1(x, y) values(2, 3);
+insert into t1 values(40, 33);
+set @str= concat('select x, y, ', fields, ' from t1');
+prepare stmt from @str; execute stmt; drop prepare stmt;
+drop table t1;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+x	y	sys_end
 3	4	2038-01-19 03:14:07.000000
 2	3	2038-01-19 03:14:07.000000
 40	33	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES(3, 4);
-INSERT INTO t1(x, y) VALUES(2, 3);
-INSERT INTO t1 VALUES(40, 33);
-SELECT x, y, Sys_end FROM t1;
-x	y	Sys_end
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+x	y	commit_ts(sys_end)
 3	4	2038-01-19 03:14:07.000000
 2	3	2038-01-19 03:14:07.000000
 40	33	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(id)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES(33, 44);
-INSERT INTO t1(id, x, y) VALUES(20, 33, 44);
-INSERT INTO t1 VALUES(40, 33, 44);
-SELECT id, x, y, Sys_end FROM t1;
-id	x	y	Sys_end
+drop procedure test_01;
+create procedure test_02(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    id int unsigned auto_increment primary key,
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+insert into t1(x, y) values(33, 44);
+insert into t1(id, x, y) values(20, 33, 44);
+insert into t1 values(40, 33, 44);
+set @str= concat('select id, x, y, ', fields, ' from t1');
+prepare stmt from @str; execute stmt; drop prepare stmt;
+drop table t1;
+end~~
+call test_02('timestamp(6)', 'myisam', 'sys_end');
+id	x	y	sys_end
 1	33	44	2038-01-19 03:14:07.000000
 20	33	44	2038-01-19 03:14:07.000000
 40	33	44	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(id)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES(33, 44);
-INSERT INTO t1(id, x, y) VALUES(20, 33, 44);
-INSERT INTO t1 VALUES(40, 33, 44);
-SELECT id, x, y, Sys_end FROM t1;
-id	x	y	Sys_end
+call test_02('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+id	x	y	commit_ts(sys_end)
 1	33	44	2038-01-19 03:14:07.000000
 20	33	44	2038-01-19 03:14:07.000000
 40	33	44	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-CREATE VIEW vt1_1 AS SELECT x, y FROM t1;
-CREATE VIEW vt1_2 AS SELECT x, y, Sys_end FROM t1;
-INSERT INTO t1(x, y) VALUES(8001, 9001);
-INSERT INTO t1(x, y, Sys_end) VALUES(8001, 9001, '2015-1-1 0:0:0');
-ERROR HY000: Generated field for System Versioning cannot be set by user
-INSERT INTO vt1_1(x, y) VALUES(1001, 2001);
-INSERT INTO vt1_1 VALUES(1002, 2002);
-INSERT INTO vt1_2(x, y) VALUES(3001, 4001);
-INSERT INTO vt1_2 VALUES(3002, 4002, '2015-1-1 0:0:0');
-ERROR HY000: Generated field for System Versioning cannot be set by user
-SELECT x, y, Sys_end FROM t1;
-x	y	Sys_end
+drop procedure test_02;
+create procedure test_03(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+create view vt1_1 as select x, y from t1;
+create view vt1_2 as select x, y, sys_end from t1;
+insert into t1(x, y) values(8001, 9001);
+insert into vt1_1(x, y) values(1001, 2001);
+insert into vt1_1 values(1002, 2002);
+insert into vt1_2(x, y) values(3001, 4001);
+set @str= concat('select x, y, ', fields, ' from t1');
+prepare stmt from @str; execute stmt; drop prepare stmt;
+select x, y from vt1_1;
+set @str= concat('select x, y, ', fields, ' from vt1_2');
+prepare stmt from @str; execute stmt; drop prepare stmt;
+end~~
+call test_03('timestamp(6)', 'myisam', 'sys_end');
+x	y	sys_end
 8001	9001	2038-01-19 03:14:07.000000
 1001	2001	2038-01-19 03:14:07.000000
 1002	2002	2038-01-19 03:14:07.000000
 3001	4001	2038-01-19 03:14:07.000000
-SELECT x, y FROM vt1_1;
 x	y
 8001	9001
 1001	2001
 1002	2002
 3001	4001
-SELECT x, y, Sys_end FROM vt1_2;
-x	y	Sys_end
+x	y	sys_end
 8001	9001	2038-01-19 03:14:07.000000
 1001	2001	2038-01-19 03:14:07.000000
 1002	2002	2038-01-19 03:14:07.000000
 3001	4001	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-DROP VIEW vt1_1;
-DROP VIEW vt1_2;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE VIEW vt1_1 AS SELECT x, y FROM t1;
-CREATE VIEW vt1_2 AS SELECT x, y, Sys_end FROM t1;
-INSERT INTO t1(x, y) VALUES(8001, 9001);
-INSERT INTO t1(x, y, Sys_end) VALUES(8001, 9001, '2015-1-1 0:0:0');
+insert into t1(x, y, sys_end) values(8001, 9001, '2015-1-1 1:1:1');
 ERROR HY000: Generated field for System Versioning cannot be set by user
-INSERT INTO vt1_1(x, y) VALUES(1001, 2001);
-INSERT INTO vt1_1 VALUES(1002, 2002);
-INSERT INTO vt1_2(x, y) VALUES(3001, 4001);
-INSERT INTO vt1_2 VALUES(3002, 4002, '2015-1-1 0:0:0');
+insert into vt1_2 values(3002, 4002, '2015-2-2 2:2:2');
 ERROR HY000: Generated field for System Versioning cannot be set by user
-SELECT x, y, Sys_end FROM t1;
-x	y	Sys_end
+drop table t1;
+drop view vt1_1;
+drop view vt1_2;
+call test_03('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+x	y	commit_ts(sys_end)
 8001	9001	2038-01-19 03:14:07.000000
 1001	2001	2038-01-19 03:14:07.000000
 1002	2002	2038-01-19 03:14:07.000000
 3001	4001	2038-01-19 03:14:07.000000
-SELECT x, y FROM vt1_1;
 x	y
 8001	9001
 1001	2001
 1002	2002
 3001	4001
-SELECT x, y, Sys_end FROM vt1_2;
-x	y	Sys_end
+x	y	commit_ts(sys_end)
 8001	9001	2038-01-19 03:14:07.000000
 1001	2001	2038-01-19 03:14:07.000000
 1002	2002	2038-01-19 03:14:07.000000
 3001	4001	2038-01-19 03:14:07.000000
-DROP TABLE t1;
-DROP VIEW vt1_1;
-DROP VIEW vt1_2;
-SET @i = 0;
-SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+insert into t1(x, y, sys_end) values(8001, 9001, 1111111);
+ERROR HY000: Generated field for System Versioning cannot be set by user
+insert into vt1_2 values(3002, 4002, 2222222);
+ERROR HY000: Generated field for System Versioning cannot be set by user
+drop table t1;
+drop view vt1_1;
+drop view vt1_2;
+drop procedure test_03;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1
 2	1	1	1	1
@@ -840,25 +891,27 @@ No	A	B	C	D
 8	1	1	1	1
 9	1	1	1	1
 10	1	1	1	1
-select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED) ENGINE=InnoDB;
-START TRANSACTION;
-INSERT INTO t1(x) VALUES(1);
-COMMIT;
-SET @i = 0;
-SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+create table t1(
+x int unsigned,
+sys_start bigint unsigned generated always as row start,
+sys_end bigint unsigned generated always as row end,
+period for system_time (sys_start, sys_end))
+with system versioning engine=innodb;
+create table t2(x int unsigned) engine=innodb;
+start transaction;
+insert into t1(x) values(1);
+commit;
+call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1
-select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-START TRANSACTION;
-INSERT INTO t2(x) VALUES(1);
-SAVEPOINT a;
-INSERT INTO t1(x) VALUES(1);
-ROLLBACK TO a;
-COMMIT;
-SET @i = 0;
-SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+start transaction;
+insert into t2(x) values(1);
+savepoint a;
+insert into t1(x) values(1);
+rollback to a;
+commit;
+call verify_vtq;
 No	A	B	C	D
-DROP TABLE t1;
-DROP TABLE t2;
+drop table t1;
+drop table t2;
+drop procedure verify_vtq;

--- a/mysql-test/r/insert_select.result
+++ b/mysql-test/r/insert_select.result
@@ -857,9 +857,26 @@ End of 5.1 tests
 # System Versioning Support
 #
 #
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=MyISAM;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=MyISAM;
-INSERT INTO t1(x, y) VALUES
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+set @str2= concat('create table t1', @str);
+prepare stmt from @str2; execute stmt; drop prepare stmt;
+set @str2= concat('create table t2', @str);
+prepare stmt from @str2; execute stmt; drop prepare stmt;
+insert into t1(x, y) values
 (1, 1000),
 (2, 2000),
 (3, 3000),
@@ -869,8 +886,8 @@ INSERT INTO t1(x, y) VALUES
 (7, 7000),
 (8, 8000),
 (9, 9000);
-DELETE FROM t1 WHERE x >= 1;
-INSERT INTO t1(x, y) VALUES
+delete from t1 where x >= 1;
+insert into t1(x, y) values
 (1, 1001),
 (2, 2001),
 (3, 3001),
@@ -880,8 +897,13 @@ INSERT INTO t1(x, y) VALUES
 (7, 7001),
 (8, 8001),
 (9, 9001);
-INSERT INTO t2 SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
+insert into t2 select x, y from t1 for system_time between timestamp '0000-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+select x, y from t1;
+select x, y from t2;
+drop table t1;
+drop table t2;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
 x	y
 1	1001
 2	2001
@@ -892,7 +914,6 @@ x	y
 7	7001
 8	8001
 9	9001
-SELECT x, y FROM t2;
 x	y
 1	1000
 2	2000
@@ -912,33 +933,7 @@ x	y
 7	7001
 8	8001
 9	9001
-DROP TABLE t1;
-DROP TABLE t2;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-(1, 1000),
-(2, 2000),
-(3, 3000),
-(4, 4000),
-(5, 5000),
-(6, 6000),
-(7, 7000),
-(8, 8000),
-(9, 9000);
-DELETE FROM t1 WHERE x >= 1;
-INSERT INTO t1(x, y) VALUES
-(1, 1001),
-(2, 2001),
-(3, 3001),
-(4, 4001),
-(5, 5001),
-(6, 6001),
-(7, 7001),
-(8, 8001),
-(9, 9001);
-INSERT INTO t2 SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
 x	y
 1	1001
 2	2001
@@ -949,7 +944,6 @@ x	y
 7	7001
 8	8001
 9	9001
-SELECT x, y FROM t2;
 x	y
 1	1000
 2	2000
@@ -969,5 +963,26 @@ x	y
 7	7001
 8	8001
 9	9001
-DROP TABLE t1;
-DROP TABLE t2;
+drop procedure test_01;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
+No	A	B	C	D
+1	1	1	1	1
+2	1	1	1	1
+3	1	1	1	1
+4	1	1	1	1
+drop procedure verify_vtq;

--- a/mysql-test/r/insert_update.result
+++ b/mysql-test/r/insert_update.result
@@ -414,8 +414,25 @@ drop table t1;
 # System Versioning Support
 #
 #
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(x, y)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end),
+    primary key(x, y))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+insert into t1(x, y) values
 (1, 1000),
 (2, 2000),
 (3, 3000),
@@ -425,11 +442,15 @@ INSERT INTO t1(x, y) VALUES
 (7, 7000),
 (8, 8000),
 (9, 9000);
-INSERT INTO t1(x, y) VALUES(3, 3000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4001) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4444) ON DUPLICATE KEY UPDATE y = y+1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
+insert into t1(x, y) values(3, 3000) on duplicate key update y = y+1;
+insert into t1(x, y) values(4, 4000) on duplicate key update y = y+1;
+insert into t1(x, y) values(4, 4001) on duplicate key update y = y+1;
+insert into t1(x, y) values(4, 4444) on duplicate key update y = y+1;
+select x, y from t1 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+select x, y from t1;
+drop table t1;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
 x	y
 1	1000
 2	2000
@@ -444,35 +465,18 @@ x	y
 4	4000
 4	4001
 4	4444
-SELECT x, y FROM t1;
 x	y
 1	1000
 2	2000
 3	3001
 4	4002
+4	4444
 5	5000
 6	6000
 7	7000
 8	8000
 9	9000
-4	4444
-DROP TABLE t1;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(x, y)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-(1, 1000),
-(2, 2000),
-(3, 3000),
-(4, 4000),
-(5, 5000),
-(6, 6000),
-(7, 7000),
-(8, 8000),
-(9, 9000);
-INSERT INTO t1(x, y) VALUES(3, 3000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4001) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4444) ON DUPLICATE KEY UPDATE y = y+1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
 x	y
 1	1000
 2	2000
@@ -487,7 +491,6 @@ x	y
 7	7000
 8	8000
 9	9000
-SELECT x, y FROM t1;
 x	y
 1	1000
 2	2000
@@ -499,4 +502,27 @@ x	y
 7	7000
 8	8000
 9	9000
-DROP TABLE t1;
+drop procedure test_01;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
+No	A	B	C	D
+1	1	1	1	1
+2	1	1	1	1
+3	1	1	1	1
+4	1	1	1	1
+5	1	1	1	1
+drop procedure verify_vtq;

--- a/mysql-test/r/multi_update.result
+++ b/mysql-test/r/multi_update.result
@@ -1066,9 +1066,26 @@ end of 10.0 tests
 # System Versioning Support
 #
 #
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+set @str2= concat('create table t1', @str);
+prepare stmt from @str2; execute stmt; drop prepare stmt;
+set @str2= concat('create table t2', @str);
+prepare stmt from @str2; execute stmt; drop prepare stmt;
+insert into t1(x, y) values
 (1, 1000),
 (2, 2000),
 (3, 3000),
@@ -1078,7 +1095,7 @@ INSERT INTO t1(x, y) VALUES
 (7, 7000),
 (8, 8000),
 (9, 9000);
-INSERT INTO t2(x, y) VALUES
+insert into t2(x, y) values
 (1, 1010),
 (2, 2010),
 (3, 3010),
@@ -1088,8 +1105,15 @@ INSERT INTO t2(x, y) VALUES
 (7, 7010),
 (8, 8010),
 (9, 9010);
-UPDATE t1, t2 SET t1.y = t1.x + t1.y, t2.y = t2.x + t2.y WHERE t1.x > 7 AND t2.x < 7;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
+update t1, t2 set t1.y = t1.x + t1.y, t2.y = t2.x + t2.y where t1.x > 7 and t2.x < 7;
+select x, y from t1 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+select x, y from t1;
+select x, y from t2 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+select x, y from t2;
+drop table t1;
+drop table t2;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
 x	y
 1	1000
 2	2000
@@ -1102,7 +1126,6 @@ x	y
 9	9009
 8	8000
 9	9000
-SELECT x, y FROM t1;
 x	y
 1	1000
 2	2000
@@ -1113,7 +1136,6 @@ x	y
 7	7000
 8	8008
 9	9009
-SELECT x, y FROM t2 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
 x	y
 1	1011
 2	2012
@@ -1130,7 +1152,6 @@ x	y
 4	4010
 5	5010
 6	6010
-SELECT x, y FROM t2;
 x	y
 1	1011
 2	2012
@@ -1141,32 +1162,7 @@ x	y
 7	7010
 8	8010
 9	9010
-DROP TABLE t1;
-DROP TABLE t2;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-(1, 1000),
-(2, 2000),
-(3, 3000),
-(4, 4000),
-(5, 5000),
-(6, 6000),
-(7, 7000),
-(8, 8000),
-(9, 9000);
-INSERT INTO t2(x, y) VALUES
-(1, 1010),
-(2, 2010),
-(3, 3010),
-(4, 4010),
-(5, 5010),
-(6, 6010),
-(7, 7010),
-(8, 8010),
-(9, 9010);
-UPDATE t1, t2 SET t1.y = t1.x + t1.y, t2.y = t2.x + t2.y WHERE t1.x > 7 AND t2.x < 7;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
 x	y
 1	1000
 2	2000
@@ -1179,7 +1175,6 @@ x	y
 9	9009
 8	8000
 9	9000
-SELECT x, y FROM t1;
 x	y
 1	1000
 2	2000
@@ -1190,7 +1185,6 @@ x	y
 7	7000
 8	8008
 9	9009
-SELECT x, y FROM t2 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
 x	y
 1	1011
 2	2012
@@ -1207,7 +1201,6 @@ x	y
 4	4010
 5	5010
 6	6010
-SELECT x, y FROM t2;
 x	y
 1	1011
 2	2012
@@ -1218,5 +1211,25 @@ x	y
 7	7010
 8	8010
 9	9010
-DROP TABLE t1;
-DROP TABLE t2;
+drop procedure test_01;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
+No	A	B	C	D
+1	1	1	1	1
+2	1	1	1	1
+3	1	1	1	1
+drop procedure verify_vtq;

--- a/mysql-test/r/update.result
+++ b/mysql-test/r/update.result
@@ -712,57 +712,24 @@ drop table t1, t2;
 # System Versioning Support
 #
 #
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
-(1, 1000),
-(2, 2000),
-(3, 3000),
-(4, 4000),
-(5, 5000),
-(6, 6000),
-(7, 7000),
-(8, 8000),
-(9, 9000);
-SELECT x, y FROM t1;
-x	y
-1	1000
-2	2000
-3	3000
-4	4000
-5	5000
-6	6000
-7	7000
-8	8000
-9	9000
-UPDATE t1 SET y = y + 1 WHERE x > 7;
-SELECT x, y FROM t1;
-x	y
-1	1000
-2	2000
-3	3000
-4	4000
-5	5000
-6	6000
-7	7000
-8	8001
-9	9001
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-x	y
-1	1000
-2	2000
-3	3000
-4	4000
-5	5000
-6	6000
-7	7000
-8	8001
-9	9001
-8	8000
-9	9000
-DROP TABLE t1;
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
+create procedure test_01(
+sys_type varchar(255),
+engine varchar(255),
+fields varchar(255))
+begin
+set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+prepare stmt from @str; execute stmt; drop prepare stmt;
+insert into t1(x, y) values
 (1, 1000),
 (2, 2000),
 (3, 3000),
@@ -772,7 +739,15 @@ INSERT INTO t1(x, y) VALUES
 (7, 7000),
 (8, 8000),
 (9, 9000);
-SELECT x, y FROM t1;
+select x, y from t1;
+update t1 set y = y + 1 where x > 7;
+select x, y from t1;
+select x, y from t1 for system_time
+between timestamp '0000-0-0 0:0:0'
+  and timestamp '2038-01-19 04:14:07';
+drop table t1;
+end~~
+call test_01('timestamp(6)', 'myisam', 'sys_end');
 x	y
 1	1000
 2	2000
@@ -783,8 +758,6 @@ x	y
 7	7000
 8	8000
 9	9000
-UPDATE t1 SET y = y + 1 WHERE x > 7;
-SELECT x, y FROM t1;
 x	y
 1	1000
 2	2000
@@ -795,7 +768,6 @@ x	y
 7	7000
 8	8001
 9	9001
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
 x	y
 1	1000
 2	2000
@@ -808,9 +780,57 @@ x	y
 9	9001
 8	8000
 9	9000
-DROP TABLE t1;
-SET @i = 0;
-SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+x	y
+1	1000
+2	2000
+3	3000
+4	4000
+5	5000
+6	6000
+7	7000
+8	8000
+9	9000
+x	y
+1	1000
+2	2000
+3	3000
+4	4000
+5	5000
+6	6000
+7	7000
+8	8001
+9	9001
+x	y
+1	1000
+2	2000
+3	3000
+4	4000
+5	5000
+6	6000
+7	7000
+8	8001
+9	9001
+8	8000
+9	9000
+drop procedure test_01;
+create procedure verify_vtq()
+begin
+set @i= 0;
+select
+@i:= @i + 1 as No,
+trx_id > 0 as A,
+begin_ts > '1-1-1 0:0:0' as B,
+commit_ts > begin_ts as C,
+concurr_trx is null as D
+from information_schema.innodb_vtq
+where trx_id > @start_trx_id;
+select ifnull(max(trx_id), 0)
+into @start_trx_id
+from information_schema.innodb_vtq;
+end~~
+call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1
 2	1	1	1	1
+drop procedure verify_vtq;

--- a/mysql-test/t/delete.test
+++ b/mysql-test/t/delete.test
@@ -585,83 +585,83 @@ DROP TABLE t1, t2;
 # SQL DELETE for SYSTEM VERSIONING
 #
 --echo #
---echo # Test for SYSTEM VERSIONING
+--echo # System Versioning Support
+--echo #
 --echo #
 
-SET @@session.time_zone='+00:00';
-
-create table t1 (
-  XNo INT UNSIGNED,
-  Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
-  Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
-  PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)
-) WITH SYSTEM VERSIONING;
-
-INSERT INTO t1(XNo) VALUES(0);
-INSERT INTO t1(XNo) VALUES(1);
-INSERT INTO t1(XNo) VALUES(2);
-INSERT INTO t1(XNo) VALUES(3);
-INSERT INTO t1(XNo) VALUES(4);
-INSERT INTO t1(XNo) VALUES(5);
-INSERT INTO t1(XNo) VALUES(6);
-INSERT INTO t1(XNo) VALUES(7);
-INSERT INTO t1(XNo) VALUES(8);
-INSERT INTO t1(XNo) VALUES(9);
-
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo = 0;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo = 1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo > 5;
-
-CREATE VIEW vt1 AS SELECT XNo FROM t1;
-
-SELECT XNo FROM vt1;
-DELETE FROM vt1 WHERE XNo = 3;
-SELECT XNo FROM vt1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-
-DROP VIEW vt1;
-DROP TABLE t1;
-
 -- source include/have_innodb.inc
-
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
 
-create table t1 (
-  XNo INT UNSIGNED,
-  Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
-  Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
-  PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)
-) WITH SYSTEM VERSIONING ENGINE InnoDB;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    XNo int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  insert into t1(XNo) values(0);
+  insert into t1(XNo) values(1);
+  insert into t1(XNo) values(2);
+  insert into t1(XNo) values(3);
+  insert into t1(XNo) values(4);
+  insert into t1(XNo) values(5);
+  insert into t1(XNo) values(6);
+  insert into t1(XNo) values(7);
+  insert into t1(XNo) values(8);
+  insert into t1(XNo) values(9);
+  set @str= concat('select XNo, ',
+  fields, " < '2038-01-19 03:14:07'
+  from t1 for system_time
+  between timestamp '0000-0-0 0:0:0'
+  and timestamp '2038-01-19 04:14:07'");
+  prepare stmt from @str; execute stmt;
+  delete from t1 where XNo = 0;
+  execute stmt;
+  delete from t1 where XNo = 1;
+  execute stmt;
+  delete from t1 where XNo > 5;
+  create view vt1 as select XNo from t1;
+  select XNo from vt1;
+  delete from vt1 where XNo = 3;
+  select XNo from vt1;
+  execute stmt; drop prepare stmt;
+  drop view vt1;
+  drop table t1;
+end~~
+delimiter ;~~
 
-INSERT INTO t1(XNo) VALUES(0);
-INSERT INTO t1(XNo) VALUES(1);
-INSERT INTO t1(XNo) VALUES(2);
-INSERT INTO t1(XNo) VALUES(3);
-INSERT INTO t1(XNo) VALUES(4);
-INSERT INTO t1(XNo) VALUES(5);
-INSERT INTO t1(XNo) VALUES(6);
-INSERT INTO t1(XNo) VALUES(7);
-INSERT INTO t1(XNo) VALUES(8);
-INSERT INTO t1(XNo) VALUES(9);
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
 
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo = 0;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo = 1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DELETE FROM t1 WHERE XNo > 5;
+# VTQ test
 
-CREATE VIEW vt1 AS SELECT XNo FROM t1;
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
 
-SELECT XNo FROM vt1;
-DELETE FROM vt1 WHERE XNo = 3;
-SELECT XNo FROM vt1;
-SELECT XNo, Sys_end < '2038-01-19 03:14:07' FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-
-DROP VIEW vt1;
-DROP TABLE t1;
-
-SET @i = 0; SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+call verify_vtq;
+drop procedure verify_vtq;

--- a/mysql-test/t/insert.test
+++ b/mysql-test/t/insert.test
@@ -580,92 +580,161 @@ DROP TABLE t1;
 --echo #
 
 -- source include/have_innodb.inc
-
-SET @@session.time_zone='+00:00';
-
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES(3, 4);
-INSERT INTO t1(x, y) VALUES(2, 3);
-INSERT INTO t1 VALUES(40, 33);
-SELECT x, y, Sys_end FROM t1;
-DROP TABLE t1;
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES(3, 4);
-INSERT INTO t1(x, y) VALUES(2, 3);
-INSERT INTO t1 VALUES(40, 33);
-SELECT x, y, Sys_end FROM t1;
-DROP TABLE t1;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values(3, 4);
+  insert into t1(x, y) values(2, 3);
+  insert into t1 values(40, 33);
+  set @str= concat('select x, y, ', fields, ' from t1');
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  drop table t1;
+end~~
+delimiter ;~~
 
-CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(id)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES(33, 44);
-INSERT INTO t1(id, x, y) VALUES(20, 33, 44);
-INSERT INTO t1 VALUES(40, 33, 44);
-SELECT id, x, y, Sys_end FROM t1;
-DROP TABLE t1;
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
 
-CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(id)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES(33, 44);
-INSERT INTO t1(id, x, y) VALUES(20, 33, 44);
-INSERT INTO t1 VALUES(40, 33, 44);
-SELECT id, x, y, Sys_end FROM t1;
-DROP TABLE t1;
+delimiter ~~;
+create procedure test_02(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    id int unsigned auto_increment primary key,
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values(33, 44);
+  insert into t1(id, x, y) values(20, 33, 44);
+  insert into t1 values(40, 33, 44);
+  set @str= concat('select id, x, y, ', fields, ' from t1');
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  drop table t1;
+end~~
+delimiter ;~~
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-CREATE VIEW vt1_1 AS SELECT x, y FROM t1;
-CREATE VIEW vt1_2 AS SELECT x, y, Sys_end FROM t1;
-INSERT INTO t1(x, y) VALUES(8001, 9001);
---error ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
-INSERT INTO t1(x, y, Sys_end) VALUES(8001, 9001, '2015-1-1 0:0:0');
-INSERT INTO vt1_1(x, y) VALUES(1001, 2001);
-INSERT INTO vt1_1 VALUES(1002, 2002);
-INSERT INTO vt1_2(x, y) VALUES(3001, 4001);
---error ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
-INSERT INTO vt1_2 VALUES(3002, 4002, '2015-1-1 0:0:0');
-SELECT x, y, Sys_end FROM t1;
-SELECT x, y FROM vt1_1;
-SELECT x, y, Sys_end FROM vt1_2;
-DROP TABLE t1;
-DROP VIEW vt1_1;
-DROP VIEW vt1_2;
+call test_02('timestamp(6)', 'myisam', 'sys_end');
+call test_02('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_02;
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE VIEW vt1_1 AS SELECT x, y FROM t1;
-CREATE VIEW vt1_2 AS SELECT x, y, Sys_end FROM t1;
-INSERT INTO t1(x, y) VALUES(8001, 9001);
---error ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
-INSERT INTO t1(x, y, Sys_end) VALUES(8001, 9001, '2015-1-1 0:0:0');
-INSERT INTO vt1_1(x, y) VALUES(1001, 2001);
-INSERT INTO vt1_1 VALUES(1002, 2002);
-INSERT INTO vt1_2(x, y) VALUES(3001, 4001);
---error ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
-INSERT INTO vt1_2 VALUES(3002, 4002, '2015-1-1 0:0:0');
-SELECT x, y, Sys_end FROM t1;
-SELECT x, y FROM vt1_1;
-SELECT x, y, Sys_end FROM vt1_2;
-DROP TABLE t1;
-DROP VIEW vt1_1;
-DROP VIEW vt1_2;
+delimiter ~~;
+create procedure test_03(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  create view vt1_1 as select x, y from t1;
+  create view vt1_2 as select x, y, sys_end from t1;
+  insert into t1(x, y) values(8001, 9001);
+  insert into vt1_1(x, y) values(1001, 2001);
+  insert into vt1_1 values(1002, 2002);
+  insert into vt1_2(x, y) values(3001, 4001);
+  set @str= concat('select x, y, ', fields, ' from t1');
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  select x, y from vt1_1;
+  set @str= concat('select x, y, ', fields, ' from vt1_2');
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+end~~
+delimiter ;~~
 
-SET @i = 0; SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+call test_03('timestamp(6)', 'myisam', 'sys_end');
+--ERROR ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
+insert into t1(x, y, sys_end) values(8001, 9001, '2015-1-1 1:1:1');
+--ERROR ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
+insert into vt1_2 values(3002, 4002, '2015-2-2 2:2:2');
+drop table t1;
+drop view vt1_1;
+drop view vt1_2;
 
-select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED) ENGINE=InnoDB;
-START TRANSACTION;
-INSERT INTO t1(x) VALUES(1);
-COMMIT;
+call test_03('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+--ERROR ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
+insert into t1(x, y, sys_end) values(8001, 9001, 1111111);
+--ERROR ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER
+insert into vt1_2 values(3002, 4002, 2222222);
+drop table t1;
+drop view vt1_1;
+drop view vt1_2;
+drop procedure test_03;
 
-SET @i = 0; SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+# VTQ test
 
-select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-START TRANSACTION;
-INSERT INTO t2(x) VALUES(1);
-SAVEPOINT a;
-INSERT INTO t1(x) VALUES(1);
-ROLLBACK TO a;
-COMMIT;
-SET @i = 0; SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
-DROP TABLE t1;
-DROP TABLE t2;
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
+
+call verify_vtq;
+
+create table t1(
+  x int unsigned,
+  sys_start bigint unsigned generated always as row start,
+  sys_end bigint unsigned generated always as row end,
+  period for system_time (sys_start, sys_end))
+with system versioning engine=innodb;
+
+create table t2(x int unsigned) engine=innodb;
+
+start transaction;
+insert into t1(x) values(1);
+commit;
+call verify_vtq;
+
+start transaction;
+insert into t2(x) values(1);
+savepoint a;
+insert into t1(x) values(1);
+rollback to a;
+commit;
+call verify_vtq;
+
+drop table t1;
+drop table t2;
+drop procedure verify_vtq;

--- a/mysql-test/t/insert_select.opt
+++ b/mysql-test/t/insert_select.opt
@@ -1,0 +1,1 @@
+--loose-innodb-vtq

--- a/mysql-test/t/insert_select.test
+++ b/mysql-test/t/insert_select.test
@@ -430,61 +430,79 @@ DROP TABLE t1;
 --echo #
 
 -- source include/have_innodb.inc
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=MyISAM;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=MyISAM;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-DELETE FROM t1 WHERE x >= 1;
-INSERT INTO t1(x, y) VALUES
-  (1, 1001),
-  (2, 2001),
-  (3, 3001),
-  (4, 4001),
-  (5, 5001),
-  (6, 6001),
-  (7, 7001),
-  (8, 8001),
-  (9, 9001);
-INSERT INTO t2 SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-SELECT x, y FROM t2;
-DROP TABLE t1;
-DROP TABLE t2;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  set @str2= concat('create table t1', @str);
+  prepare stmt from @str2; execute stmt; drop prepare stmt;
+  set @str2= concat('create table t2', @str);
+  prepare stmt from @str2; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values
+    (1, 1000),
+    (2, 2000),
+    (3, 3000),
+    (4, 4000),
+    (5, 5000),
+    (6, 6000),
+    (7, 7000),
+    (8, 8000),
+    (9, 9000);
+  delete from t1 where x >= 1;
+  insert into t1(x, y) values
+    (1, 1001),
+    (2, 2001),
+    (3, 3001),
+    (4, 4001),
+    (5, 5001),
+    (6, 6001),
+    (7, 7001),
+    (8, 8001),
+    (9, 9001);
+  insert into t2 select x, y from t1 for system_time between timestamp '0000-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+  select x, y from t1;
+  select x, y from t2;
+  drop table t1;
+  drop table t2;
+end~~
+delimiter ;~~
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-DELETE FROM t1 WHERE x >= 1;
-INSERT INTO t1(x, y) VALUES
-  (1, 1001),
-  (2, 2001),
-  (3, 3001),
-  (4, 4001),
-  (5, 5001),
-  (6, 6001),
-  (7, 7001),
-  (8, 8001),
-  (9, 9001);
-INSERT INTO t2 SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-SELECT x, y FROM t2;
-DROP TABLE t1;
-DROP TABLE t2;
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
+
+# VTQ test
+
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
+
+call verify_vtq;
+drop procedure verify_vtq;

--- a/mysql-test/t/insert_update.opt
+++ b/mysql-test/t/insert_update.opt
@@ -1,0 +1,1 @@
+--loose-innodb-vtq

--- a/mysql-test/t/insert_update.test
+++ b/mysql-test/t/insert_update.test
@@ -314,41 +314,69 @@ drop table t1;
 --echo #
 
 -- source include/have_innodb.inc
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(x, y)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-INSERT INTO t1(x, y) VALUES(3, 3000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4001) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4444) ON DUPLICATE KEY UPDATE y = y+1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-DROP TABLE t1;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end),
+    primary key(x, y))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values
+    (1, 1000),
+    (2, 2000),
+    (3, 3000),
+    (4, 4000),
+    (5, 5000),
+    (6, 6000),
+    (7, 7000),
+    (8, 8000),
+    (9, 9000);
+  insert into t1(x, y) values(3, 3000) on duplicate key update y = y+1;
+  insert into t1(x, y) values(4, 4000) on duplicate key update y = y+1;
+  insert into t1(x, y) values(4, 4001) on duplicate key update y = y+1;
+  insert into t1(x, y) values(4, 4444) on duplicate key update y = y+1;
+  select x, y from t1 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+  select x, y from t1;
+  drop table t1;
+end~~
+delimiter ;~~
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end), PRIMARY KEY(x, y)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-INSERT INTO t1(x, y) VALUES(3, 3000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4000) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4001) ON DUPLICATE KEY UPDATE y = y+1;
-INSERT INTO t1(x, y) VALUES(4, 4444) ON DUPLICATE KEY UPDATE y = y+1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-DROP TABLE t1;
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
+
+# VTQ test
+
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
+
+call verify_vtq;
+drop procedure verify_vtq;

--- a/mysql-test/t/multi_update.opt
+++ b/mysql-test/t/multi_update.opt
@@ -1,0 +1,1 @@
+--loose-innodb-vtq

--- a/mysql-test/t/multi_update.test
+++ b/mysql-test/t/multi_update.test
@@ -1090,62 +1090,81 @@ DROP VIEW v1;
 --echo #
 --echo #
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-INSERT INTO t2(x, y) VALUES
-  (1, 1010),
-  (2, 2010),
-  (3, 3010),
-  (4, 4010),
-  (5, 5010),
-  (6, 6010),
-  (7, 7010),
-  (8, 8010),
-  (9, 9010);
-UPDATE t1, t2 SET t1.y = t1.x + t1.y, t2.y = t2.x + t2.y WHERE t1.x > 7 AND t2.x < 7;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-SELECT x, y FROM t2 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t2;
-DROP TABLE t1;
-DROP TABLE t2;
+-- source include/have_innodb.inc
+set @@session.time_zone='+00:00';
+select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-CREATE TABLE t2(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-INSERT INTO t2(x, y) VALUES
-  (1, 1010),
-  (2, 2010),
-  (3, 3010),
-  (4, 4010),
-  (5, 5010),
-  (6, 6010),
-  (7, 7010),
-  (8, 8010),
-  (9, 9010);
-UPDATE t1, t2 SET t1.y = t1.x + t1.y, t2.y = t2.x + t2.y WHERE t1.x > 7 AND t2.x < 7;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t1;
-SELECT x, y FROM t2 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0-0-0 0:0:0' AND TIMESTAMP '9999-1-1 0:0:0';
-SELECT x, y FROM t2;
-DROP TABLE t1;
-DROP TABLE t2;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  set @str2= concat('create table t1', @str);
+  prepare stmt from @str2; execute stmt; drop prepare stmt;
+  set @str2= concat('create table t2', @str);
+  prepare stmt from @str2; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values
+    (1, 1000),
+    (2, 2000),
+    (3, 3000),
+    (4, 4000),
+    (5, 5000),
+    (6, 6000),
+    (7, 7000),
+    (8, 8000),
+    (9, 9000);
+  insert into t2(x, y) values
+    (1, 1010),
+    (2, 2010),
+    (3, 3010),
+    (4, 4010),
+    (5, 5010),
+    (6, 6010),
+    (7, 7010),
+    (8, 8010),
+    (9, 9010);
+  update t1, t2 set t1.y = t1.x + t1.y, t2.y = t2.x + t2.y where t1.x > 7 and t2.x < 7;
+  select x, y from t1 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+  select x, y from t1;
+  select x, y from t2 for system_time between timestamp '0-0-0 0:0:0' and timestamp '9999-1-1 0:0:0';
+  select x, y from t2;
+  drop table t1;
+  drop table t2;
+end~~
+delimiter ;~~
+
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
+
+# VTQ test
+
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
+
+call verify_vtq;
+drop procedure verify_vtq;

--- a/mysql-test/t/update.test
+++ b/mysql-test/t/update.test
@@ -660,41 +660,69 @@ drop table t1, t2;
 --echo #
 --echo #
 
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-SELECT x, y FROM t1;
-UPDATE t1 SET y = y + 1 WHERE x > 7;
-SELECT x, y FROM t1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DROP TABLE t1;
-
 -- source include/have_innodb.inc
-
+set @@session.time_zone='+00:00';
 select ifnull(max(trx_id), 0) into @start_trx_id from information_schema.innodb_vtq;
-CREATE TABLE t1(x INT UNSIGNED, y INT UNSIGNED, Sys_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START, Sys_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (Sys_start, Sys_end)) WITH SYSTEM VERSIONING ENGINE=InnoDB;
-INSERT INTO t1(x, y) VALUES
-  (1, 1000),
-  (2, 2000),
-  (3, 3000),
-  (4, 4000),
-  (5, 5000),
-  (6, 6000),
-  (7, 7000),
-  (8, 8000),
-  (9, 9000);
-SELECT x, y FROM t1;
-UPDATE t1 SET y = y + 1 WHERE x > 7;
-SELECT x, y FROM t1;
-SELECT x, y FROM t1 FOR SYSTEM_TIME BETWEEN TIMESTAMP '0000-0-0 0:0:0' AND TIMESTAMP '2038-01-19 04:14:07';
-DROP TABLE t1;
 
-SET @i = 0; SELECT @i:=@i+1 AS No, trx_id > 0 AS A, begin_ts > '2015-1-1 0:0:0' AS B, commit_ts > begin_ts AS C, concurr_trx IS NULL AS D FROM INFORMATION_SCHEMA.INNODB_VTQ WHERE trx_id > @start_trx_id;
+delimiter ~~;
+create procedure test_01(
+  sys_type varchar(255),
+  engine varchar(255),
+  fields varchar(255))
+begin
+  set @str= concat('
+  create table t1(
+    x int unsigned,
+    y int unsigned,
+    sys_start ', sys_type, ' generated always as row start,
+    sys_end ', sys_type, ' generated always as row end,
+    period for system_time (sys_start, sys_end))
+  with system versioning
+  engine ', engine);
+  prepare stmt from @str; execute stmt; drop prepare stmt;
+  insert into t1(x, y) values
+    (1, 1000),
+    (2, 2000),
+    (3, 3000),
+    (4, 4000),
+    (5, 5000),
+    (6, 6000),
+    (7, 7000),
+    (8, 8000),
+    (9, 9000);
+  select x, y from t1;
+  update t1 set y = y + 1 where x > 7;
+  select x, y from t1;
+  select x, y from t1 for system_time
+  between timestamp '0000-0-0 0:0:0'
+  and timestamp '2038-01-19 04:14:07';
+  drop table t1;
+end~~
+delimiter ;~~
+
+call test_01('timestamp(6)', 'myisam', 'sys_end');
+call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_end)');
+drop procedure test_01;
+
+# VTQ test
+
+delimiter ~~;
+create procedure verify_vtq()
+begin
+  set @i= 0;
+  select
+    @i:= @i + 1 as No,
+    trx_id > 0 as A,
+    begin_ts > '1-1-1 0:0:0' as B,
+    commit_ts > begin_ts as C,
+    concurr_trx is null as D
+  from information_schema.innodb_vtq
+  where trx_id > @start_trx_id;
+  select ifnull(max(trx_id), 0)
+  into @start_trx_id
+  from information_schema.innodb_vtq;
+end~~
+delimiter ;~~
+
+call verify_vtq;
+drop procedure verify_vtq;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -5458,7 +5458,7 @@ bool Field_timestampf::set_max()
   DBUG_ENTER("Field_timestampf::set_max");
   ASSERT_COLUMN_MARKED_FOR_WRITE_OR_COMPUTED;
 
-  mi_int4store(ptr, 0x7fffffff);
+  mi_int4store(ptr, TIMESTAMP_MAX_VALUE);
   memset(ptr + 4, 0x0, value_length() - 4);
 
   DBUG_RETURN(FALSE);

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -33,6 +33,7 @@
 #include "structs.h"                            /* SHOW_COMP_OPTION */
 #include "sql_array.h"          /* Dynamic_array<> */
 #include "mdl.h"
+#include "vtq.h"
 
 #include "sql_analyze_stmt.h" // for Exec_time_tracker 
 
@@ -1356,9 +1357,10 @@ struct handlerton
                                    TABLE_SHARE *share, HA_CREATE_INFO *info);
 
    /*
-     Engine supports System Versioning
+     System Versioning
    */
-   bool versioned();
+   bool versioned() const;
+   bool (*vers_get_vtq_ts)(THD* thd, MYSQL_TIME *out, ulonglong trx_id, vtq_field_t field);
 };
 
 
@@ -4351,7 +4353,7 @@ void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag);
 void print_keydup_error(TABLE *table, KEY *key, myf errflag);
 
 inline
-bool handlerton::versioned()
+bool handlerton::versioned() const
 {
   return flags & HTON_SUPPORTS_SYS_VERSIONING;
 }

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -4956,6 +4956,7 @@ bool Item_field::fix_fields(THD *thd, Item **reference)
       expression to 'reference', i.e. it substitute that expression instead
       of this Item_field
     */
+    DBUG_ASSERT(context);
     if ((from_field= find_field_in_tables(thd, this,
                                           context->first_name_resolution_table,
                                           context->last_name_resolution_table,

--- a/sql/item.h
+++ b/sql/item.h
@@ -3510,7 +3510,7 @@ public:
 class Item_datetime_literal: public Item_temporal_literal
 {
 public:
-  Item_datetime_literal(THD *thd, MYSQL_TIME *ltime, uint dec_arg):
+  Item_datetime_literal(THD *thd, MYSQL_TIME *ltime, uint dec_arg= 0):
     Item_temporal_literal(thd, ltime, dec_arg)
   {
     max_length= MAX_DATETIME_WIDTH + (decimals ? decimals + 1 : 0);

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -5720,6 +5720,92 @@ Create_func_year_week::create_native(THD *thd, LEX_STRING name,
 }
 
 
+/* System Versioning: BEGIN_TS(), COMMIT_TS() */
+
+class Create_func_begin_ts : public Create_native_func
+{
+public:
+  virtual Item *create_native(THD *thd, LEX_STRING name, List<Item> *item_list);
+
+  static Create_func_begin_ts s_singleton;
+
+protected:
+  Create_func_begin_ts() {}
+  virtual ~Create_func_begin_ts() {}
+};
+
+Create_func_begin_ts Create_func_begin_ts::s_singleton;
+
+Item*
+Create_func_begin_ts::create_native(THD *thd, LEX_STRING name,
+  List<Item> *item_list)
+{
+  Item *func= NULL;
+  int arg_count= 0;
+
+  if (item_list != NULL)
+    arg_count= item_list->elements;
+
+  switch (arg_count) {
+  case 1:
+  {
+    Item *param_1= item_list->pop();
+    func= new (thd->mem_root) Item_func_vtq_ts(thd, param_1, VTQ_BEGIN_TS);
+    break;
+  }
+  default:
+  {
+    my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name.str);
+    break;
+  }
+  }
+
+  return func;
+}
+
+class Create_func_commit_ts : public Create_native_func
+{
+public:
+  virtual Item *create_native(THD *thd, LEX_STRING name, List<Item> *item_list);
+
+  static Create_func_commit_ts s_singleton;
+
+protected:
+  Create_func_commit_ts() {}
+  virtual ~Create_func_commit_ts() {}
+};
+
+Create_func_commit_ts Create_func_commit_ts::s_singleton;
+
+Item*
+Create_func_commit_ts::create_native(THD *thd, LEX_STRING name,
+  List<Item> *item_list)
+{
+  Item *func= NULL;
+  int arg_count= 0;
+
+  if (item_list != NULL)
+    arg_count= item_list->elements;
+
+  switch (arg_count) {
+  case 1:
+  {
+    Item *param_1= item_list->pop();
+    func= new (thd->mem_root) Item_func_vtq_ts(thd, param_1, VTQ_COMMIT_TS);
+    break;
+  }
+  default:
+  {
+    my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name.str);
+    break;
+  }
+  }
+
+  return func;
+}
+
+
+
 struct Native_func_registry
 {
   LEX_STRING name;
@@ -5760,6 +5846,7 @@ static Native_func_registry func_array[] =
   { { C_STRING_WITH_LEN("ASWKT") }, GEOM_BUILDER(Create_func_as_wkt)},
   { { C_STRING_WITH_LEN("ATAN") }, BUILDER(Create_func_atan)},
   { { C_STRING_WITH_LEN("ATAN2") }, BUILDER(Create_func_atan)},
+  { { C_STRING_WITH_LEN("BEGIN_TS") }, BUILDER(Create_func_begin_ts)},
   { { C_STRING_WITH_LEN("BENCHMARK") }, BUILDER(Create_func_benchmark)},
   { { C_STRING_WITH_LEN("BIN") }, BUILDER(Create_func_bin)},
   { { C_STRING_WITH_LEN("BINLOG_GTID_POS") }, BUILDER(Create_func_binlog_gtid_pos)},
@@ -5777,6 +5864,7 @@ static Native_func_registry func_array[] =
   { { C_STRING_WITH_LEN("COLUMN_EXISTS") }, BUILDER(Create_func_dyncol_exists)},
   { { C_STRING_WITH_LEN("COLUMN_LIST") }, BUILDER(Create_func_dyncol_list)},
   { { C_STRING_WITH_LEN("COLUMN_JSON") }, BUILDER(Create_func_dyncol_json)},
+  { { C_STRING_WITH_LEN("COMMIT_TS") }, BUILDER(Create_func_commit_ts)},
   { { C_STRING_WITH_LEN("COMPRESS") }, BUILDER(Create_func_compress)},
   { { C_STRING_WITH_LEN("CONCAT") }, BUILDER(Create_func_concat)},
   { { C_STRING_WITH_LEN("CONCAT_WS") }, BUILDER(Create_func_concat_ws)},

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -3241,3 +3241,71 @@ bool Item_func_last_day::get_date(MYSQL_TIME *ltime, ulonglong fuzzy_date)
   ltime->time_type= MYSQL_TIMESTAMP_DATE;
   return (null_value= 0);
 }
+
+Item_func_vtq_ts::Item_func_vtq_ts(
+    THD *thd,
+    Item* a,
+    vtq_field_t _vtq_field,
+    handlerton* _hton) :
+  Item_datetimefunc(thd, a),
+  vtq_field(_vtq_field),
+  hton(_hton)
+{
+  decimals= 6;
+  null_value= true;
+  DBUG_ASSERT(arg_count == 1 && args[0]);
+}
+
+Item_func_vtq_ts::Item_func_vtq_ts(
+    THD *thd,
+    Item* a,
+    vtq_field_t _vtq_field) :
+  Item_datetimefunc(thd, a),
+  vtq_field(_vtq_field),
+  hton(NULL)
+{
+  decimals= 6;
+  null_value= true;
+  DBUG_ASSERT(arg_count == 1 && args[0]);
+}
+
+bool Item_func_vtq_ts::get_date(MYSQL_TIME *res, ulonglong fuzzy_date)
+{
+  THD *thd= current_thd; // can it differ from constructor's?
+  DBUG_ASSERT(thd);
+  ulonglong trx_id= args[0]->val_uint();
+  if (trx_id == ULONGLONG_MAX)
+  {
+    null_value= false;
+    thd->variables.time_zone->gmt_sec_to_TIME(res, TIMESTAMP_MAX_VALUE);
+    return false;
+  }
+
+  if (!hton)
+  {
+    if (args[0]->type() == Item::FIELD_ITEM)
+    {
+      Item_field *f=
+        static_cast<Item_field *>(args[0]);
+      DBUG_ASSERT(
+        f->field &&
+        f->field->table &&
+        f->field->table->s &&
+        f->field->table->s->db_plugin);
+      hton= plugin_hton(f->field->table->s->db_plugin);
+      DBUG_ASSERT(hton);
+    }
+    else if (innodb_plugin)
+    {
+      hton= plugin_hton(plugin_int_to_ref(innodb_plugin));
+      DBUG_ASSERT(hton);
+    }
+  }
+
+  if (!hton)
+    return true;
+
+  null_value= !hton->vers_get_vtq_ts(thd, res, trx_id, vtq_field);
+
+  return false;
+}

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -1114,4 +1114,24 @@ public:
   bool get_date(MYSQL_TIME *res, ulonglong fuzzy_date);
 };
 
+#include "vtq.h"
+
+class Item_func_vtq_ts :public Item_datetimefunc
+{
+  vtq_field_t vtq_field;
+  handlerton *hton;
+public:
+  Item_func_vtq_ts(THD *thd, Item* a, vtq_field_t _vtq_field, handlerton *hton);
+  Item_func_vtq_ts(THD *thd, Item* a, vtq_field_t _vtq_field);
+  const char *func_name() const
+  {
+    if (vtq_field == VTQ_BEGIN_TS)
+    {
+      return "begin_ts";
+    }
+    return "commit_ts";
+  }
+  bool get_date(MYSQL_TIME *res, ulonglong fuzzy_date);
+};
+
 #endif /* ITEM_TIMEFUNC_INCLUDED */

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2492,6 +2492,7 @@ sp_head::restore_thd_mem_root(THD *thd)
   Item *flist= free_list;	// The old list
   set_query_arena(thd);         // Get new free_list and mem_root
   state= STMT_INITIALIZED_FOR_SP;
+  is_stored_procedure= true;
 
   DBUG_PRINT("info", ("mem_root 0x%lx returned from thd mem root 0x%lx",
                       (ulong) &mem_root, (ulong) &thd->mem_root));

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8739,7 +8739,7 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
                           ER_THD(thd, ER_WARNING_NON_DEFAULT_VALUE_FOR_VIRTUAL_COLUMN),
                           rfield->field_name, table->s->table_name.str);
     }
-    if (table->versioned_by_sql() && rfield->is_generated() &&
+    if (table->versioned() && rfield->is_generated() &&
         !ignore_errors)
     {
       my_error(ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER, MYF(0));
@@ -8960,7 +8960,7 @@ fill_record(THD *thd, TABLE *table, Field **ptr, List<Item> &values,
                           field->field_name, table->s->table_name.str);
     }
 
-    if (table->versioned_by_sql() && field->is_generated() &&
+    if (table->versioned() && field->is_generated() &&
         !ignore_errors)
     {
       my_error(ER_GENERATED_FIELD_CANNOT_BE_SET_BY_USER, MYF(0));

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -3646,6 +3646,7 @@ void Query_arena::set_query_arena(Query_arena *set)
   mem_root=  set->mem_root;
   free_list= set->free_list;
   state= set->state;
+  is_stored_procedure= set->is_stored_procedure;
 }
 
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -910,6 +910,11 @@ public:
 
   enum_state state;
 
+protected:
+  friend class sp_head;
+  bool is_stored_procedure;
+
+public:
   /* We build without RTTI, so dynamic_cast can't be used. */
   enum Type
   {
@@ -917,7 +922,8 @@ public:
   };
 
   Query_arena(MEM_ROOT *mem_root_arg, enum enum_state state_arg) :
-    free_list(0), mem_root(mem_root_arg), state(state_arg)
+    free_list(0), mem_root(mem_root_arg), state(state_arg),
+    is_stored_procedure(state_arg == STMT_INITIALIZED_FOR_SP ? true : false)
   { INIT_ARENA_DBUG_INFO; }
   /*
     This constructor is used only when Query_arena is created as
@@ -937,6 +943,8 @@ public:
   { return state == STMT_PREPARED || state == STMT_EXECUTED; }
   inline bool is_conventional() const
   { return state == STMT_CONVENTIONAL_EXECUTION; }
+  inline bool is_sp_execute() const
+  { return is_stored_procedure; }
 
   inline void* alloc(size_t size) { return alloc_root(mem_root,size); }
   inline void* calloc(size_t size)

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -2115,6 +2115,7 @@ void st_select_lex::init_query()
   item_list.empty();
   join= 0;
   having= prep_having= where= prep_where= 0;
+  saved_conds= 0;
   olap= UNSPECIFIED_OLAP_TYPE;
   having_fix_field= 0;
   context.select_lex= this;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -737,6 +737,7 @@ public:
   Item *where, *having;                         /* WHERE & HAVING clauses */
   Item *prep_where; /* saved WHERE clause for prepared statement processing */
   Item *prep_having;/* saved HAVING clause for prepared statement processing */
+  Item *saved_conds;
   /* Saved values of the WHERE and HAVING clauses*/
   Item::cond_result cond_value, having_value;
   /* point on lex in which it was created, used in view subquery detection */

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -233,6 +233,8 @@ static int plugin_array_version=0;
 static bool initialized= 0;
 ulong dlopen_count;
 
+st_plugin_int* innodb_plugin= NULL;
+
 
 /*
   write-lock on LOCK_system_variables_hash is required before modifying
@@ -1422,6 +1424,18 @@ static int plugin_initialize(MEM_ROOT *tmp_root, struct st_plugin_int *plugin,
     }
   }
   state= PLUGIN_IS_READY; // plugin->init() succeeded
+
+  {
+    static const char * INNODB= "InnoDB";
+    static const uint INNODB_LEN= strlen(INNODB);
+
+    if (!my_strnncoll(&my_charset_latin1,
+      (const uchar *) plugin->name.str, plugin->name.length,
+      (const uchar *) INNODB, INNODB_LEN))
+    {
+      innodb_plugin= plugin;
+    }
+  }
 
   if (plugin->plugin->status_vars)
   {

--- a/sql/sql_plugin.h
+++ b/sql/sql_plugin.h
@@ -158,6 +158,8 @@ extern ulong plugin_maturity;
 extern TYPELIB plugin_maturity_values;
 extern const char *plugin_maturity_names[];
 
+extern st_plugin_int* innodb_plugin;
+
 extern int plugin_init(int *argc, char **argv, int init_flags);
 extern void plugin_shutdown(void);
 void add_plugin_options(DYNAMIC_ARRAY *options, MEM_ROOT *mem_root);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -55,6 +55,7 @@
 #include "sql_statistics.h"
 #include "sql_cte.h"
 #include "sql_window.h"
+#include "tztime.h"
 
 #include "debug_sync.h"          // DEBUG_SYNC
 #include <m_ctype.h>
@@ -678,10 +679,19 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
 
   TABLE_LIST *table;
   int versioned_tables= 0;
+  Query_arena *arena= 0, backup;
+  bool is_prepare= thd->stmt_arena->is_stmt_prepare();
+
+  if (!thd->stmt_arena->is_conventional()
+    && !is_prepare
+    && !thd->stmt_arena->is_sp_execute())
+  {
+    DBUG_RETURN(0);
+  }
 
   for (table= tables; table; table= table->next_local)
   {
-    if (table->table && table->table->versioned_by_sql())
+    if (table->table && table->table->versioned())
       versioned_tables++;
     else if (table->system_versioning.type != FOR_SYSTEM_TIME_UNSPECIFIED)
     {
@@ -693,50 +703,113 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
   if (versioned_tables == 0)
     DBUG_RETURN(0);
 
+  /* For prepared statements we create items on statement arena,
+     because they must outlive execution phase for multiple executions. */
+  arena= thd->activate_stmt_arena_if_needed(&backup);
+
+  if (select_lex->saved_conds)
+  {
+    DBUG_ASSERT(thd->stmt_arena->is_sp_execute());
+    *conds= select_lex->saved_conds;
+  }
+  else if (thd->stmt_arena->is_sp_execute())
+  {
+    if (thd->stmt_arena->is_stmt_execute())
+      *conds= 0;
+    else if (*conds)
+      select_lex->saved_conds= (*conds)->copy_andor_structure(thd);
+  }
+
   for (table= tables; table; table= table->next_local)
   {
-    if (table->table && table->table->versioned_by_sql())
+    if (table->table && table->table->versioned())
     {
       Field *fstart= table->table->vers_start_field();
       Field *fend= table->table->vers_end_field();
-      Item *istart= new (thd->mem_root) Item_field(thd, fstart);
-      Item *iend= new (thd->mem_root) Item_field(thd, fend);
-      Item *cond1= 0, *cond2= 0, *curr = 0;
+
+      DBUG_ASSERT(select_lex->parent_lex);
+      Name_resolution_context *context= select_lex->parent_lex->current_context();
+      DBUG_ASSERT(context);
+
+      Item *row_start= new (thd->mem_root) Item_field(thd, context, fstart);
+      Item *row_end= new (thd->mem_root) Item_field(thd, context, fend);
+      Item *row_end2= row_end;
+
+      if (!table->table->versioned_by_sql())
+      {
+        DBUG_ASSERT(table->table->s && table->table->s->db_plugin);
+        row_start= new (thd->mem_root) Item_func_vtq_ts(
+          thd,
+          row_start,
+          VTQ_COMMIT_TS,
+          plugin_hton(table->table->s->db_plugin));
+        row_end= new (thd->mem_root) Item_func_vtq_ts(
+          thd,
+          row_end,
+          VTQ_COMMIT_TS,
+          plugin_hton(table->table->s->db_plugin));
+      }
+
+      Item *cond1= 0, *cond2= 0, *curr= 0;
       switch (table->system_versioning.type)
       {
         case FOR_SYSTEM_TIME_UNSPECIFIED:
-          curr= new (thd->mem_root) Item_func_now_local(thd, 6);
-          cond1= new (thd->mem_root) Item_func_le(thd, istart, curr);
-          cond2= new (thd->mem_root) Item_func_gt(thd, iend, curr);
+          if (table->table->versioned_by_sql())
+          {
+            MYSQL_TIME max_time;
+            thd->variables.time_zone->gmt_sec_to_TIME(&max_time, TIMESTAMP_MAX_VALUE);
+            curr= new (thd->mem_root) Item_datetime_literal(thd, &max_time);
+            cond1= new (thd->mem_root) Item_func_eq(thd, row_end, curr);
+          }
+          else
+          {
+            curr= new (thd->mem_root) Item_int(thd, ULONGLONG_MAX);
+            cond1= new (thd->mem_root) Item_func_eq(thd, row_end2, curr);
+          }
           break;
         case FOR_SYSTEM_TIME_AS_OF:
-          cond1= new (thd->mem_root) Item_func_le(thd, istart,
-                                                  table->system_versioning.start);
-          cond2= new (thd->mem_root) Item_func_gt(thd, iend,
-                                                  table->system_versioning.start);
+          cond1= new (thd->mem_root) Item_func_le(thd, row_start,
+            table->system_versioning.start);
+          cond2= new (thd->mem_root) Item_func_gt(thd, row_end,
+            table->system_versioning.start);
           break;
         case FOR_SYSTEM_TIME_FROM_TO:
-          cond1= new (thd->mem_root) Item_func_lt(thd, istart,
+          cond1= new (thd->mem_root) Item_func_lt(thd, row_start,
                                                   table->system_versioning.end);
-          cond2= new (thd->mem_root) Item_func_ge(thd, iend,
+          cond2= new (thd->mem_root) Item_func_ge(thd, row_end,
                                                   table->system_versioning.start);
           break;
         case FOR_SYSTEM_TIME_BETWEEN:
-          cond1= new (thd->mem_root) Item_func_le(thd, istart,
+          cond1= new (thd->mem_root) Item_func_le(thd, row_start,
                                                   table->system_versioning.end);
-          cond2= new (thd->mem_root) Item_func_ge(thd, iend,
+          cond2= new (thd->mem_root) Item_func_ge(thd, row_end,
                                                   table->system_versioning.start);
           break;
         default:
           DBUG_ASSERT(0);
       }
-      if (cond1 && cond2)
+
+      if (cond1)
       {
-        COND *system_time_cond= new (thd->mem_root) Item_cond_and(thd, cond1, cond2);
-        thd->change_item_tree(conds, and_items(thd, *conds, system_time_cond));
+        cond1= and_items(thd,
+          *conds,
+          and_items(thd,
+            cond2,
+            cond1));
+
+        if (arena)
+          *conds= cond1;
+        else
+          thd->change_item_tree(conds, cond1);
+
         table->system_versioning.is_moved_to_where= true;
       }
     }
+  }
+
+  if (arena)
+  {
+    thd->restore_active_arena(arena, &backup);
   }
 
   DBUG_RETURN(0);

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2010,7 +2010,7 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
                           hton->index_options);
   }
 
-  if (table->versioned_by_sql())
+  if (table->versioned())
   {
     const Field *fs = table->vers_start_field();
     const Field *fe = table->vers_end_field();
@@ -2087,7 +2087,7 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
       }
     }
 
-    if (table->versioned_by_sql())
+    if (table->versioned())
     {
       packet->append(STRING_WITH_LEN(" WITH SYSTEM VERSIONING"));
     }

--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -476,18 +476,6 @@ void localtime_to_TIME(MYSQL_TIME *to, struct tm *from)
 }
 
 
-/*
-  Convert seconds since Epoch to TIME
-*/
-
-void unix_time_to_TIME(MYSQL_TIME *to, time_t secs, suseconds_t usecs)
-{
-  struct tm tm_time;
-  localtime_r(&secs, &tm_time);
-  localtime_to_TIME(to, &tm_time);
-  to->second_part = usecs;
-}
-
 void calc_time_from_sec(MYSQL_TIME *to, long seconds, long microseconds)
 {
   long t_seconds;

--- a/sql/sql_time.h
+++ b/sql/sql_time.h
@@ -171,15 +171,6 @@ bool calc_time_diff(const MYSQL_TIME *l_time1, const MYSQL_TIME *l_time2,
                     int lsign, MYSQL_TIME *l_time3, ulonglong fuzzydate);
 int my_time_compare(const MYSQL_TIME *a, const MYSQL_TIME *b);
 void localtime_to_TIME(MYSQL_TIME *to, struct tm *from);
-void unix_time_to_TIME(MYSQL_TIME *to, time_t secs, suseconds_t usecs);
-
-inline
-longlong unix_time_to_packed(time_t secs, suseconds_t usecs)
-{
-  MYSQL_TIME mysql_time;
-  unix_time_to_TIME(&mysql_time, secs, usecs);
-  return pack_time(&mysql_time);
-}
 
 void calc_time_from_sec(MYSQL_TIME *to, long seconds, long microseconds);
 uint calc_week(MYSQL_TIME *l_time, uint week_behaviour, uint *year);

--- a/sql/vtq.h
+++ b/sql/vtq.h
@@ -1,0 +1,25 @@
+#ifndef VTQ_INCLUDED
+#define VTQ_INCLUDED
+/* Copyright (c) 2016, MariaDB Corporation.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA */
+
+enum vtq_field_t
+{
+  VTQ_BEGIN_TS = 0,
+  VTQ_COMMIT_TS
+};
+
+#endif /* VTQ_INCLUDED */
+

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -1500,11 +1500,11 @@ dict_create_or_check_vtq_table(void)
 	if (sys_vtq_err == DB_CORRUPTION) {
 		ib_logf(IB_LOG_LEVEL_WARN,
 			"Dropping incompletely created "
-			"SYS_FOREIGN table.");
+			"SYS_VTQ table.");
 		row_drop_table_for_mysql("SYS_VTQ", trx, TRUE);
 	}
 
-	ib_logf(IB_LOG_LEVEL_WARN,
+	ib_logf(IB_LOG_LEVEL_INFO,
 		"Creating VTQ system table.");
 
 	srv_file_per_table_backup = srv_file_per_table;

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -753,8 +753,8 @@ dict_process_sys_vtq(
 mem_heap_t*	heap,		/*!< in/out: heap memory */
 const rec_t*	rec,		/*!< in: current rec */
 trx_id_t*	col_trx_id,	/*!< out: field values */
-ullong*		col_begin_ts,
-ullong*		col_commit_ts,
+timeval*	col_begin_ts,
+timeval*	col_commit_ts,
 char**		col_concurr_trx)
 {
 	ulint		len, col, concurr_n;
@@ -784,7 +784,8 @@ char**		col_concurr_trx)
 	if (len != sizeof(ullong))
 		return dict_print_error(heap, col, len, sizeof(ullong));
 
-	*col_begin_ts = mach_read_from_8(field);
+	col_begin_ts->tv_sec = mach_read_from_4(field);
+	col_begin_ts->tv_usec = mach_read_from_4(field + 4);
 	/* COMMIT_TS */
 	field = rec_get_nth_field_old(
 		rec, (col = DICT_FLD__SYS_VTQ__COMMIT_TS), &len);
@@ -792,7 +793,8 @@ char**		col_concurr_trx)
 	if (len != sizeof(ullong))
 		return dict_print_error(heap, col, len, sizeof(ullong));
 
-	*col_commit_ts = mach_read_from_8(field);
+	col_commit_ts->tv_sec = mach_read_from_4(field);
+	col_commit_ts->tv_usec = mach_read_from_4(field + 4);
 	/* CONCURR_TRX */
 	field = rec_get_nth_field_old(
 		rec, (col = DICT_FLD__SYS_VTQ__CONCURR_TRX), &len);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -33,6 +33,10 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 *****************************************************************************/
 
+#define MYSQL_SERVER
+#include <sql_class.h>
+#include <tztime.h>
+
 #define lower_case_file_system lower_case_file_system_server
 #define mysql_unpacked_real_data_home mysql_unpacked_real_data_home_server
 #include <sql_table.h>	// explain_filename, nz2, EXPLAIN_PARTITIONS_AS_COMMENT,
@@ -113,6 +117,7 @@ MYSQL_PLUGIN_IMPORT extern char mysql_unpacked_real_data_home[];
 #include "fts0priv.h"
 #include "page0zip.h"
 #include "fil0pagecompress.h"
+#include "vtq.h"
 
 #define thd_get_trx_isolation(X) ((enum_tx_isolation)thd_tx_isolation(X))
 
@@ -1439,6 +1444,9 @@ normalize_table_name_low(
 	const char*     name,           /* in: table name string */
 	ibool           set_lower_case); /* in: TRUE if we want to set
 					 name to lower case */
+
+bool
+innobase_get_vtq_ts(THD* thd, MYSQL_TIME *out, ulonglong in_trx_id, vtq_field_t field);
 
 /*************************************************************//**
 Check for a valid value of innobase_commit_concurrency.
@@ -3364,6 +3372,9 @@ innobase_init(
           innobase_hton->tablefile_extensions = ha_innobase_exts;
 
 	innobase_hton->table_options = innodb_table_option_list;
+
+	/* System Versioning */
+	innobase_hton->vers_get_vtq_ts = innobase_get_vtq_ts;
 
 	innodb_remember_check_sysvar_funcs();
 
@@ -20642,4 +20653,111 @@ ib_push_warning(
 		buf);
 	my_free(buf);
 	va_end(args);
+}
+
+
+inline
+void
+innobase_get_vtq_ts_result(THD* thd, vtq_query_t* q, MYSQL_TIME *out, vtq_field_t field)
+{
+	ut_ad(thd && thd->variables.time_zone);
+
+	switch (field) {
+	case VTQ_BEGIN_TS:
+		thd->variables.time_zone->gmt_sec_to_TIME(out, q->begin_ts.tv_sec);
+		out->second_part = q->begin_ts.tv_usec;
+		break;
+	case VTQ_COMMIT_TS:
+		thd->variables.time_zone->gmt_sec_to_TIME(out, q->commit_ts.tv_sec);
+		out->second_part = q->commit_ts.tv_usec;
+		break;
+	default:
+		ut_error;
+	}
+}
+
+UNIV_INTERN
+bool
+innobase_get_vtq_ts(THD* thd, MYSQL_TIME *out, ulonglong _in_trx_id, vtq_field_t field)
+{
+	trx_t*		trx;
+	dict_index_t*	index;
+	btr_pcur_t	pcur;
+	dtuple_t*	tuple;
+	dfield_t*	dfield;
+	trx_id_t	trx_id_net;
+	mtr_t		mtr;
+	mem_heap_t*	heap;
+	rec_t*		rec;
+	ulint		len;
+	byte*		result_net;
+	bool		found = false;
+
+	DBUG_ENTER("innobase_get_vtq_ts");
+
+	if (_in_trx_id == 0) {
+		DBUG_RETURN(false);
+	}
+
+	ut_ad(sizeof(_in_trx_id) == sizeof(trx_id_t));
+	trx_id_t	in_trx_id = static_cast<trx_id_t>(_in_trx_id);
+
+	trx = thd_to_trx(thd);
+	ut_a(trx);
+	vtq_query_t*	q = &trx->vtq_query;
+
+	if (q->trx_id == in_trx_id) {
+		innobase_get_vtq_ts_result(thd, q, out, field);
+		DBUG_RETURN(true);
+	}
+
+	index = dict_table_get_first_index(dict_sys->sys_vtq);
+	heap = mem_heap_create(0);
+
+	ut_ad(index);
+	ut_ad(dict_index_is_clust(index));
+
+	mach_write_to_8(
+		reinterpret_cast<byte*>(&trx_id_net),
+		in_trx_id);
+
+	tuple = dtuple_create(heap, 1);
+	dfield = dtuple_get_nth_field(tuple, DICT_FLD__SYS_VTQ__TRX_ID);
+	dfield_set_data(dfield, &trx_id_net, 8);
+	dict_index_copy_types(tuple, index, 1);
+
+	mtr_start_trx(&mtr, trx);
+	btr_pcur_open_on_user_rec(index, tuple, PAGE_CUR_GE,
+			BTR_SEARCH_LEAF, &pcur, &mtr);
+
+	if (!btr_pcur_is_on_user_rec(&pcur))
+		goto not_found;
+
+	rec = btr_pcur_get_rec(&pcur);
+	result_net = rec_get_nth_field_old(rec, DICT_FLD__SYS_VTQ__TRX_ID, &len);
+	ut_ad(len == 8);
+	q->trx_id = mach_read_from_8(result_net);
+
+	result_net = rec_get_nth_field_old(rec, DICT_FLD__SYS_VTQ__BEGIN_TS, &len);
+	ut_ad(len == 8);
+	q->begin_ts.tv_sec = mach_read_from_4(result_net);
+	q->begin_ts.tv_usec = mach_read_from_4(result_net + 4);
+
+	result_net = rec_get_nth_field_old(rec, DICT_FLD__SYS_VTQ__COMMIT_TS, &len);
+	ut_ad(len == 8);
+	q->commit_ts.tv_sec = mach_read_from_4(result_net);
+	q->commit_ts.tv_usec = mach_read_from_4(result_net + 4);
+
+	if (q->trx_id != in_trx_id)
+		goto not_found;
+
+	innobase_get_vtq_ts_result(thd, q, out, field);
+	found = true;
+
+not_found:
+	btr_pcur_close(&pcur);
+	mtr_commit(&mtr);
+	mem_heap_free(heap);
+
+	DBUG_RETURN(found);
 }

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -25,6 +25,10 @@ Created July 18, 2007 Vasil Dimov
 Modified Dec 29, 2014 Jan Lindström (Added sys_semaphore_waits)
 *******************************************************/
 
+#define MYSQL_SERVER
+#include <sql_class.h>
+#include <tztime.h>
+
 #include "univ.i"
 
 #include <mysqld_error.h>
@@ -358,22 +362,20 @@ Auxiliary function to store packed timestamp value in MYSQL_TYPE_DATETIME field.
 If the value is ULINT_UNDEFINED then the field it set to NULL.
 @return	0 on success */
 int
-field_store_packed_ts(
+field_store_timeval(
 /*==============*/
 Field*	field,	/*!< in/out: target field for storage */
-ullong	n)	/*!< in: value to store */
+timeval	t,	/*!< in: value to store */
+THD*	thd)
 {
 	int	ret;
 	MYSQL_TIME tmp;
 
-	if (n != UINT64_UNDEFINED) {
-		unpack_time(n, &tmp);
-		ret = field->store_time(&tmp);
-		field->set_notnull();
-	} else {
-		ret = 0; /* success */
-		field->set_null();
-	}
+	ut_ad(thd && thd->variables.time_zone);
+	thd->variables.time_zone->gmt_sec_to_TIME(&tmp, t.tv_sec);
+	tmp.second_part = t.tv_usec;
+	ret = field->store_time(&tmp);
+	field->set_notnull();
 
 	return(ret);
 }
@@ -9242,8 +9244,8 @@ i_s_dict_fill_vtq(
 /*========================*/
 	THD*		thd,		/*!< in: thread */
 	ullong		col_trx_id,	/*!< in: table fields */
-	ullong		col_begin_ts,
-	ullong		col_commit_ts,
+	timeval&	col_begin_ts,
+	timeval&	col_commit_ts,
 	char*		col_concurr_trx,
 	TABLE*		table_to_fill)	/*!< in/out: fill this table */
 {
@@ -9253,8 +9255,8 @@ i_s_dict_fill_vtq(
 	fields = table_to_fill->field;
 
 	OK(field_store_ullong(fields[SYS_VTQ_TRX_ID], col_trx_id));
-	OK(field_store_packed_ts(fields[SYS_VTQ_BEGIN_TS], col_begin_ts));
-	OK(field_store_packed_ts(fields[SYS_VTQ_COMMIT_TS], col_commit_ts));
+	OK(field_store_timeval(fields[SYS_VTQ_BEGIN_TS], col_begin_ts, thd));
+	OK(field_store_timeval(fields[SYS_VTQ_COMMIT_TS], col_commit_ts, thd));
 	OK(field_store_string(fields[SYS_VTQ_CONCURR_TRX], col_concurr_trx));
 
 	OK(schema_table_store_record(thd, table_to_fill));
@@ -9301,8 +9303,8 @@ i_s_sys_vtq_fill_table(
 	for (int i = 0; rec && i < I_S_SYS_VTQ_LIMIT; ++i) {
 		const char*	err_msg;
 		trx_id_t	col_trx_id;
-		ullong		col_begin_ts;
-		ullong		col_commit_ts;
+		timeval		col_begin_ts;
+		timeval		col_commit_ts;
 		char*		col_concurr_trx;
 
 		/* Extract necessary information from SYS_VTQ row */

--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -400,8 +400,8 @@ dict_process_sys_vtq(
 mem_heap_t*	heap,		/*!< in/out: heap memory */
 const rec_t*	rec,		/*!< in: current rec */
 ullong*		col_trx_id,	/*!< out: field values */
-ullong*		col_begin_ts,
-ullong*		col_commit_ts,
+timeval*	col_begin_ts,
+timeval*	col_commit_ts,
 char**		col_concurr_trx);
 /********************************************************************//**
 Get the filepath for a spaceid from SYS_DATAFILES. This function provides

--- a/storage/innobase/include/row0ins.ic
+++ b/storage/innobase/include/row0ins.ic
@@ -35,10 +35,25 @@ void set_row_field_8(
 	dfield_t* dfield = dtuple_get_nth_field(row, field_num);
 	ut_ad(dfield->type.len == fsize);
 	if (dfield->len == UNIV_SQL_NULL) {
-		byte* buf = static_cast<byte*>(mem_heap_alloc(heap, fsize));
-		mach_write_to_8(buf, data);
+		byte* buf = reinterpret_cast<byte*>(mem_heap_alloc(heap, fsize));
 		dfield_set_data(dfield, buf, fsize);
-	} else {
-		mach_write_to_8(dfield->data, data);
 	}
+	mach_write_to_8(dfield->data, data);
+}
+
+UNIV_INLINE
+void set_row_field_8(
+	dtuple_t* row,
+	int field_num,
+	timeval& data,
+	mem_heap_t* heap)
+{
+	dfield_t* dfield = dtuple_get_nth_field(row, field_num);
+	ut_ad(dfield->type.len == 8);
+	if (dfield->len == UNIV_SQL_NULL) {
+		byte* buf = reinterpret_cast<byte*>(mem_heap_alloc(heap, 8));
+		dfield_set_data(dfield, buf, 8);
+	}
+	mach_write_to_4(reinterpret_cast<byte*>(dfield->data), (ulint) data.tv_sec);
+	mach_write_to_4(reinterpret_cast<byte*>(dfield->data) + 4, (ulint) data.tv_usec);
 }

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -39,6 +39,7 @@ Created 3/26/1996 Heikki Tuuri
 #include "trx0xa.h"
 #include "ut0vec.h"
 #include "fts0fts.h"
+#include "pars0pars.h"
 
 /** Dummy session used currently in MySQL interface */
 extern sess_t*	trx_dummy_sess;
@@ -679,6 +680,13 @@ typedef enum {
 	TRX_REPLICATION_ABORT = 2
 } trx_abort_t;
 
+struct vtq_query_t
+{
+	trx_id_t	trx_id;
+	timeval		begin_ts;
+	timeval		commit_ts;
+};
+
 struct trx_t{
 	ulint		magic_n;
 
@@ -1031,7 +1039,12 @@ struct trx_t{
 	os_event_t	wsrep_event;	/* event waited for in srv_conc_slot */
 #endif /* WITH_WSREP */
 
-	bool vtq_notify_on_commit;	/*!< Notify VTQ for System Versioned update */
+	/* System Versioning */
+	bool		vtq_notify_on_commit;
+					/*!< Notify VTQ for System Versioned update */
+	vtq_query_t	vtq_query;
+	trx_id_t*	vtq_concurr_trx;
+	ulint		vtq_concurr_n;
 };
 
 /* Transaction isolation levels (trx->isolation_level) */

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -52,7 +52,6 @@ Created 4/20/1996 Heikki Tuuri
 #include "fts0fts.h"
 #include "fts0types.h"
 #include "m_string.h"
-#include "sql_time.h"
 
 /*************************************************************************
 IMPORTANT NOTE: Any operation that generates redo MUST check that there
@@ -3461,12 +3460,6 @@ vers_row_ins_vtq_low(trx_t* trx, mem_heap_t* heap, dtuple_t* row)
 		err = row_ins_sec_index_entry_low(
 			flags, BTR_MODIFY_TREE,
 			index, offsets_heap, heap, entry, trx->id, NULL, trx);
-
-		///* Report correct index name for duplicate key error. */
-		// No need to report on commit phase?
-		//if (err == DB_DUPLICATE_KEY) {
-		//	trx->error_key_num = n_index;
-		//}
 	} while (err == DB_SUCCESS);
 
 	mem_heap_free(offsets_heap);
@@ -3482,10 +3475,10 @@ void vers_notify_vtq(trx_t* trx)
 	mem_heap_t* heap = mem_heap_create(1024);
 	dtuple_t* row = dtuple_create(heap, dict_table_get_n_cols(dict_sys->sys_vtq));
 
-	ulint now_secs, now_usecs;
-	ut_usectime(&now_secs, &now_usecs);
-	ullong begin_ts = unix_time_to_packed(trx->start_time, trx->start_time_us);
-	ullong commit_ts = unix_time_to_packed(now_secs, now_usecs);
+	timeval begin_ts, commit_ts;
+	begin_ts.tv_sec = trx->start_time;
+	begin_ts.tv_usec = trx->start_time_us;
+	ut_usectime((ulint *)&commit_ts.tv_sec, (ulint *)&commit_ts.tv_usec);
 
 	dict_table_copy_types(row, dict_sys->sys_vtq);
 	set_row_field_8(row, DICT_FLD__SYS_VTQ__TRX_ID, trx->id, heap);
@@ -3493,35 +3486,16 @@ void vers_notify_vtq(trx_t* trx)
 	set_row_field_8(row, DICT_FLD__SYS_VTQ__COMMIT_TS - 2, commit_ts, heap);
 
 	dfield_t* dfield = dtuple_get_nth_field(row, DICT_FLD__SYS_VTQ__CONCURR_TRX - 2);
-	mutex_enter(&trx_sys->mutex);
-	trx_list_t &rw_list = trx_sys->rw_trx_list;
-	if (rw_list.count > 1) {
-		byte* buf = static_cast<byte*>(mem_heap_alloc(heap, rw_list.count * 8));
-		byte* ptr = buf;
-		ulint count = 0;
-
-		for (trx_t* ctrx = UT_LIST_GET_FIRST(rw_list);
-			ctrx != NULL;
-			ctrx = UT_LIST_GET_NEXT(trx_list, ctrx))
-		{
-			if (ctrx == trx || ctrx->state == TRX_STATE_NOT_STARTED)
-				continue;
-
-			mach_write_to_8(ptr, ctrx->id);
-			++count;
+	ulint count = 0;
+	byte* buf = NULL;
+	if (trx->vtq_concurr_n > 0) {
+		buf = static_cast<byte*>(mem_heap_alloc(heap, trx->vtq_concurr_n * 8));
+		for (byte* ptr = buf; count < trx->vtq_concurr_n; ++count) {
+			mach_write_to_8(ptr, trx->vtq_concurr_trx[count]);
 			ptr += 8;
 		}
-
-		if (count)
-			dfield_set_data(dfield, buf, count * 8);
-		else
-			dfield_set_data(dfield, NULL, 0);
-	} else {
-		// there must be at least current transaction
-		ut_ad(rw_list.count == 1 && UT_LIST_GET_FIRST(rw_list) == trx);
-		dfield_set_data(dfield, NULL, 0);
 	}
-	mutex_exit(&trx_sys->mutex);
+	dfield_set_data(dfield, buf, count * 8);
 
 	err = vers_row_ins_vtq_low(trx, heap, row);
 	if (DB_SUCCESS != err)

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1360,11 +1360,21 @@ row_insert_for_mysql(
 
 	if (DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED)) {
 		ut_ad(table->vers_row_start != table->vers_row_end);
+		/* Return back modified fields into mysql_rec, so that
+		   upper logic may benefit from it (f.ex. 'on duplicate key'). */
+		const mysql_row_templ_t* t = &prebuilt->mysql_template[table->vers_row_end];
+		ut_ad(t->mysql_col_len == 8);
+
 		if (historical) {
 			set_row_field_8(node->row, table->vers_row_end, trx->id, node->entry_sys_heap);
+			int8store(&mysql_rec[t->mysql_col_offset], trx->id);
 		} else {
-			set_row_field_8(node->row, table->vers_row_start, trx->id, node->entry_sys_heap);
 			set_row_field_8(node->row, table->vers_row_end, IB_UINT64_MAX, node->entry_sys_heap);
+			int8store(&mysql_rec[t->mysql_col_offset], IB_UINT64_MAX);
+			t = &prebuilt->mysql_template[table->vers_row_start];
+			ut_ad(t->mysql_col_len == 8);
+			set_row_field_8(node->row, table->vers_row_start, trx->id, node->entry_sys_heap);
+			int8store(&mysql_rec[t->mysql_col_offset], trx->id);
 		}
 	}
 
@@ -1799,20 +1809,25 @@ row_update_for_mysql(
 
 	if (DICT_TF2_FLAG_IS_SET(node->table, DICT_TF2_VERSIONED))
 	{
-		/* System Versioning: update sys_trx_start to current trx_id */
+		/* System Versioning: modify update vector to set
+		   sys_trx_start (or sys_trx_end in case of DELETE)
+		   to current trx_id. */
 		upd_t* uvect = node->update;
 		upd_field_t* ufield;
 		dict_col_t* col;
+		const mysql_row_templ_t* t;
+		unsigned col_idx;
 		if (node->is_delete) {
 			ufield = &uvect->fields[0];
 			uvect->n_fields = 0;
 			node->is_delete = false;
-			col = &table->cols[table->vers_row_end];
+			col_idx = table->vers_row_end;
 		} else {
 			ut_ad(uvect->n_fields < node->table->n_cols);
 			ufield = &uvect->fields[uvect->n_fields];
-			col = &table->cols[table->vers_row_start];
+			col_idx = table->vers_row_start;
 		}
+		col = &table->cols[col_idx];
 		UNIV_MEM_INVALID(ufield, sizeof *ufield);
 		ufield->field_no = dict_col_get_clust_pos(col, clust_index);
 		ufield->orig_len = 0;
@@ -1827,6 +1842,11 @@ row_update_for_mysql(
 
 		uvect->n_fields++;
 		ut_ad(node->in_mysql_interface); // otherwise needs to recalculate node->cmpl_info
+
+		/* Return trx_id back to mysql_rec (for the sake of interface consistency). */
+		t = &prebuilt->mysql_template[col_idx];
+		ut_ad(t->mysql_col_len == 8);
+		int8store(&mysql_rec[t->mysql_col_offset], trx->id);
 	}
 
 	ut_a(node->pcur->rel_pos == BTR_PCUR_ON);


### PR DESCRIPTION
- BEGIN_TS(), COMMIT_TS() SQL functions;
- VTQ instead of packed stores secs + usecs like my_timestamp_to_binary() does;
- versioned SELECT to IB is translated with COMMIT_TS();
- SQL fixes:
  - FOR_SYSTEM_TIME_UNSPECIFIED condition compares to TIMESTAMP_MAX_VALUE;
  - segfault fix #36: multiple execute of prepared stmt;
  - different tables to same stored procedure fix (#39)
- Fixes of previous parts: ON DUPLICATE KEY, other misc fixes.

Closes #20

Please, review.
