### PR TITLE
Parser: versioned JOIN fix

### DIFF
--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -2193,6 +2193,7 @@ void st_select_lex::init_select()
   m_agg_func_used= false;
   name_visibility_map= 0;
   join= 0;
+  vers_conditions.empty();
 }
 
 /*

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -912,6 +912,9 @@ public:
   /* namp of nesting SELECT visibility (for aggregate functions check) */
   nesting_map name_visibility_map;
 
+  /* System Versioning conditions */
+  vers_select_conds_t vers_conditions;
+
   void init_query();
   void init_select();
   st_select_lex_unit* master_unit() { return (st_select_lex_unit*) master; }

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -693,11 +693,6 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
   {
     if (table->table && table->table->versioned())
       versioned_tables++;
-    else if (table->system_versioning.type != FOR_SYSTEM_TIME_UNSPECIFIED)
-    {
-      my_error(ER_TABLE_DOESNT_SUPPORT_SYSTEM_VERSIONING, MYF(0), table->table_name);
-      DBUG_RETURN(-1);
-    }
   }
 
   if (versioned_tables == 0)
@@ -751,7 +746,7 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
       }
 
       Item *cond1= 0, *cond2= 0, *curr= 0;
-      switch (table->system_versioning.type)
+      switch (select_lex->vers_conditions.type)
       {
         case FOR_SYSTEM_TIME_UNSPECIFIED:
           if (table->table->versioned_by_sql())
@@ -769,21 +764,21 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
           break;
         case FOR_SYSTEM_TIME_AS_OF:
           cond1= new (thd->mem_root) Item_func_le(thd, row_start,
-            table->system_versioning.start);
+            select_lex->vers_conditions.start);
           cond2= new (thd->mem_root) Item_func_gt(thd, row_end,
-            table->system_versioning.start);
+            select_lex->vers_conditions.start);
           break;
         case FOR_SYSTEM_TIME_FROM_TO:
           cond1= new (thd->mem_root) Item_func_lt(thd, row_start,
-                                                  table->system_versioning.end);
+                                                  select_lex->vers_conditions.end);
           cond2= new (thd->mem_root) Item_func_ge(thd, row_end,
-                                                  table->system_versioning.start);
+                                                  select_lex->vers_conditions.start);
           break;
         case FOR_SYSTEM_TIME_BETWEEN:
           cond1= new (thd->mem_root) Item_func_le(thd, row_start,
-                                                  table->system_versioning.end);
+                                                  select_lex->vers_conditions.end);
           cond2= new (thd->mem_root) Item_func_ge(thd, row_end,
-                                                  table->system_versioning.start);
+                                                  select_lex->vers_conditions.start);
           break;
         default:
           DBUG_ASSERT(0);
@@ -802,10 +797,10 @@ setup_for_system_time(THD *thd, TABLE_LIST *tables, COND **conds, SELECT_LEX *se
         else
           thd->change_item_tree(conds, cond1);
 
-        table->system_versioning.is_moved_to_where= true;
+        table->vers_moved_to_where= true;
       }
-    }
-  }
+    } // if (... table->table->versioned())
+  } // for (table= tables; ...)
 
   if (arena)
   {
@@ -24664,29 +24659,30 @@ bool mysql_explain_union(THD *thd, SELECT_LEX_UNIT *unit, select_result *result)
 void TABLE_LIST::print_system_versioning(THD *thd, table_map eliminated_tables,
                    String *str, enum_query_type query_type)
 {
-  if (system_versioning.is_moved_to_where)
+  if (vers_moved_to_where)
     return;
 
+  DBUG_ASSERT(select_lex);
   // system versioning
-  if (system_versioning.type != FOR_SYSTEM_TIME_UNSPECIFIED)
+  if (select_lex->vers_conditions.type != FOR_SYSTEM_TIME_UNSPECIFIED)
   {
-    switch (system_versioning.type)
+    switch (select_lex->vers_conditions.type)
     {
       case FOR_SYSTEM_TIME_AS_OF:
         str->append(STRING_WITH_LEN(" for system_time as of "));
-        system_versioning.start->print(str, query_type);
+        select_lex->vers_conditions.start->print(str, query_type);
         break;
       case FOR_SYSTEM_TIME_FROM_TO:
         str->append(STRING_WITH_LEN(" for system_time from timestamp "));
-        system_versioning.start->print(str, query_type);
+        select_lex->vers_conditions.start->print(str, query_type);
         str->append(STRING_WITH_LEN(" to "));
-        system_versioning.end->print(str, query_type);
+        select_lex->vers_conditions.end->print(str, query_type);
         break;
       case FOR_SYSTEM_TIME_BETWEEN:
         str->append(STRING_WITH_LEN(" for system_time between timestamp "));
-        system_versioning.start->print(str, query_type);
+        select_lex->vers_conditions.start->print(str, query_type);
         str->append(STRING_WITH_LEN(" and "));
-        system_versioning.end->print(str, query_type);
+        select_lex->vers_conditions.end->print(str, query_type);
         break;
       default:
         DBUG_ASSERT(0);

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -957,7 +957,6 @@ bool LEX::set_bincmp(CHARSET_INFO *cs, bool bin)
   Lex_cast_type_st Lex_cast_type;
   Lex_field_type_st Lex_field_type;
   Lex_dyncol_type_st Lex_dyncol_type;
-  system_versioning_for_select system_versioning;
 
   /* pointers */
   Create_field *create_field;
@@ -2054,7 +2053,6 @@ END_OF_INPUT
 %type <NONE> window_frame_extent;
 %type <frame_exclusion> opt_window_frame_exclusion;
 %type <window_frame_bound> window_frame_start window_frame_bound;
-%type <system_versioning> opt_for_system_time_clause;
 
 %type <NONE>
         '-' '+' '*' '/' '%' '(' ')'
@@ -8808,6 +8806,7 @@ table_expression:
           opt_group_clause
           opt_having_clause
           opt_window_clause
+          opt_for_system_time_clause
         ;
 
 opt_table_expression:
@@ -8847,14 +8846,12 @@ select_options:
 
 opt_for_system_time_clause:
           /* empty */
-          {
-            $$.init();
-          }
+          {}
         | FOR_SYSTEM_TIME_SYM
           AS OF_SYM
           TIMESTAMP simple_expr
           {
-            $$.init(FOR_SYSTEM_TIME_AS_OF, $5);
+            Lex->current_select->vers_conditions.init(FOR_SYSTEM_TIME_AS_OF, $5);
           }
         | FOR_SYSTEM_TIME_SYM
           AS OF_SYM
@@ -8863,7 +8860,7 @@ opt_for_system_time_clause:
             Item *item= new (thd->mem_root) Item_func_now_local(thd, 6);
             if (item == NULL)
               MYSQL_YYABORT;
-            $$.init(FOR_SYSTEM_TIME_AS_OF, item);
+            Lex->current_select->vers_conditions.init(FOR_SYSTEM_TIME_AS_OF, item);
           }
         | FOR_SYSTEM_TIME_SYM
           FROM
@@ -8871,7 +8868,7 @@ opt_for_system_time_clause:
           TO_SYM
           TIMESTAMP simple_expr
           {
-            $$.init(FOR_SYSTEM_TIME_FROM_TO, $4, $7);
+            Lex->current_select->vers_conditions.init(FOR_SYSTEM_TIME_FROM_TO, $4, $7);
           }
         | FOR_SYSTEM_TIME_SYM
           BETWEEN_SYM
@@ -8879,7 +8876,7 @@ opt_for_system_time_clause:
           AND_SYM
           TIMESTAMP simple_expr
           {
-            $$.init(FOR_SYSTEM_TIME_BETWEEN, $4, $7);
+            Lex->current_select->vers_conditions.init(FOR_SYSTEM_TIME_BETWEEN, $4, $7);
           }
         ;
 
@@ -11193,7 +11190,7 @@ table_primary_ident:
             SELECT_LEX *sel= Select;
             sel->table_join_options= 0;
           }
-          table_ident opt_use_partition opt_table_alias opt_key_definition opt_for_system_time_clause
+          table_ident opt_use_partition opt_table_alias opt_key_definition
           {
             if (!($$= Select->add_table_to_list(thd, $2, $4,
                                                 Select->get_table_join_options(),
@@ -11203,7 +11200,6 @@ table_primary_ident:
                                                 $3)))
               MYSQL_YYABORT;
             Select->add_joined_table($$);
-            $$->system_versioning= $6;
           }
         ;
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -1765,26 +1765,32 @@ class Item_in_subselect;
 
 enum for_system_time_type
 {
-  FOR_SYSTEM_TIME_UNSPECIFIED, FOR_SYSTEM_TIME_AS_OF,
-  FOR_SYSTEM_TIME_FROM_TO, FOR_SYSTEM_TIME_BETWEEN
+  FOR_SYSTEM_TIME_UNSPECIFIED = 0,
+  FOR_SYSTEM_TIME_AS_OF,
+  FOR_SYSTEM_TIME_FROM_TO,
+  FOR_SYSTEM_TIME_BETWEEN
 };
 
 /** System versioning support. */
-struct system_versioning_for_select
+struct vers_select_conds_t
 {
   enum for_system_time_type type;
   Item *start, *end;
-  bool is_moved_to_where;
+
+  void empty()
+  {
+    type= FOR_SYSTEM_TIME_UNSPECIFIED;
+    start= end= NULL;
+  }
 
   void init(
-    const enum for_system_time_type t=FOR_SYSTEM_TIME_UNSPECIFIED,
-    Item * const s=NULL,
-    Item * const e=NULL)
+    const enum for_system_time_type t,
+    Item * const s,
+    Item * const e= NULL)
   {
     type= t;
     start= s;
     end= e;
-    is_moved_to_where= false;
   }
 };
 
@@ -2221,8 +2227,8 @@ struct TABLE_LIST
   TABLE_LIST *first_leaf_for_name_resolution();
   TABLE_LIST *last_leaf_for_name_resolution();
 
-  /** System versioning support. */
-  system_versioning_for_select system_versioning;
+  /* System Versioning */
+  bool vers_moved_to_where;
 
   /**
      @brief


### PR DESCRIPTION
Moved opt_for_system_time_clause from table identifier (which binds
it to single table) to table expression.

Please, review ASAP.

Daniel, what is TABLE_LIST::print_system_versioning(), what's its use cases? Is it covered by tests?
