### PR TITLE
Hide implicitly added versioning fields from SELECT *

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -167,6 +167,7 @@ enum enum_server_command
 #define WITHOUT_SYSTEM_VERSIONING_FLAG (1 << 30) /* column that doesn't support
                                                     system versioning when table
                                                     itself supports it*/
+#define HIDDEN_FLAG (1 << 31) /* hide from SELECT * */
 
 #define REFRESH_GRANT           (1ULL << 0)  /* Refresh grant tables */
 #define REFRESH_LOG             (1ULL << 1)  /* Start on new log file */

--- a/mysql-test/suite/versioning/r/select.result
+++ b/mysql-test/suite/versioning/r/select.result
@@ -241,6 +241,21 @@ RJ2_x1	y1	x2	y2
 1	3	1	2
 NULL	NULL	2	1
 NULL	NULL	3	1
+create table t1(
+A int
+) with system versioning engine=myisam;
+insert into t1 values(1);
+select * from t1;
+A
+1
+create or replace table t1(
+A int
+) with system versioning engine=innodb;
+insert into t1 values(1);
+select * from t1;
+A
+1
+drop table t1;
 call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1
@@ -251,6 +266,7 @@ No	A	B	C	D
 6	1	1	1	1
 7	1	1	1	1
 8	1	1	1	1
+9	1	1	1	1
 drop procedure test_01;
 drop procedure test_02;
 drop procedure verify_vtq;

--- a/mysql-test/suite/versioning/t/select.test
+++ b/mysql-test/suite/versioning/t/select.test
@@ -89,6 +89,22 @@ call test_01('bigint unsigned', 'innodb', 'commit_ts(sys_start)');
 call test_02('timestamp(6)', 'myisam', 'sys_start');
 call test_02('bigint unsigned', 'innodb', 'commit_ts(sys_start)');
 
+# Test wildcard expansion on hidden fields.
+create table t1(
+  A int
+) with system versioning engine=myisam;
+insert into t1 values(1);
+select * from t1;
+
+create or replace table t1(
+  A int
+) with system versioning engine=innodb;
+insert into t1 values(1);
+select * from t1;
+
+drop table t1;
+# End test wildcard expansion.
+
 call verify_vtq;
 
 drop procedure test_01;

--- a/sql/field.h
+++ b/sql/field.h
@@ -3950,6 +3950,8 @@ int convert_null_to_field_value_or_error(Field *field);
 #define FIELDFLAG_BITFIELD		512	// mangled with decimals!
 #define FIELDFLAG_BLOB			1024	// mangled with decimals!
 #define FIELDFLAG_GEOM			2048    // mangled with decimals!
+// Do not show field in SELECT *. Hope GEOM field is never hidden.
+#define FIELDFLAG_HIDDEN                2048U
 
 #define FIELDFLAG_TREAT_BIT_AS_CHAR     4096    /* use Field_bit_as_char */
 
@@ -3988,5 +3990,6 @@ int convert_null_to_field_value_or_error(Field *field);
 #define f_bit_as_char(x)        ((x) & FIELDFLAG_TREAT_BIT_AS_CHAR)
 #define f_is_hex_escape(x)      ((x) & FIELDFLAG_HEX_ESCAPE)
 #define f_without_system_versioning(x) ((x) & FIELDFLAG_WITHOUT_SYSTEM_VERSIONING)
+#define f_hidden(x)             ((x) & FIELDFLAG_HIDDEN)
 
 #endif /* FIELD_INCLUDED */

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6344,16 +6344,16 @@ static bool create_sys_trx_field(THD *thd, const char *field_name,
   memset(f, 0, sizeof(*f));
   f->field_name= field_name;
   f->charset= system_charset_info;
+  f->flags= NOT_NULL_FLAG | HIDDEN_FLAG;
   if (integer_fields)
   {
     f->sql_type= MYSQL_TYPE_LONGLONG;
-    f->flags= UNSIGNED_FLAG | NOT_NULL_FLAG;
+    f->flags|= UNSIGNED_FLAG;
     f->length= MY_INT64_NUM_DECIMAL_DIGITS;
   }
   else
   {
     f->sql_type= MYSQL_TYPE_TIMESTAMP2;
-    f->flags= NOT_NULL_FLAG;
     f->length= 6;
   }
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8345,6 +8345,14 @@ insert_fields(THD *thd, Name_resolution_context *context, const char *db_name,
       if (!(item= field_iterator.create_item(thd)))
         DBUG_RETURN(TRUE);
 
+      if (item->type() == Item::FIELD_ITEM)
+      {
+        Item_field *f= static_cast<Item_field *>(item);
+        DBUG_ASSERT(f->field);
+        if (f->field->flags & HIDDEN_FLAG)
+          continue;
+      }
+
       /* cache the table for the Item_fields inserted by expanding stars */
       if (item->type() == Item::FIELD_ITEM && tables->cacheable_table)
         ((Item_field *)item)->cached_table= tables;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3022,6 +3022,8 @@ int prepare_create_field(Column_definition *sql_field,
     sql_field->pack_flag|= FIELDFLAG_NO_DEFAULT;
   if (sql_field->flags & WITHOUT_SYSTEM_VERSIONING_FLAG)
     sql_field->pack_flag|= FIELDFLAG_WITHOUT_SYSTEM_VERSIONING;
+  if (sql_field->flags & HIDDEN_FLAG)
+    sql_field->pack_flag|= FIELDFLAG_HIDDEN;
   DBUG_RETURN(0);
 }
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -1717,6 +1717,9 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
     if (f_without_system_versioning(pack_flag))
       reg_field->flags|= WITHOUT_SYSTEM_VERSIONING_FLAG;
 
+    if (f_hidden(pack_flag))
+      reg_field->flags|= HIDDEN_FLAG;
+
     if (reg_field->unireg_check == Field::NEXT_NUMBER)
       share->found_next_number_field= field_ptr;
 


### PR DESCRIPTION
This is not much work but I think it's ok for our need now. And this patch should be reverted once this https://github.com/MariaDB/server/compare/10.2...SachinSetiya:unique_index_sachin will be comited to MariaDB and we'll rebase on newer MariaDB trunk.
