### PR TITLE
IB: trx start time

### DIFF
--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1354,16 +1354,6 @@ trx_start_low(
 	ut_usectime((ulong *)&trx->start_time,
 		(ulong *)&trx->start_time_micro);
 
-	if (trx->mysql_thd != NULL) {
-		time_t start_time = thd_start_time_in_secs(trx->mysql_thd);
-		ib_uint64_t start_utime = thd_query_start_micro(trx->mysql_thd);
-		if (start_time < trx->start_time ||
-			(start_time == trx->start_time && start_utime < trx->start_time_micro))
-		{
-			trx->start_time = start_time;
-			trx->start_time_micro = start_utime;
-		}
-	}
 
 	trx->vtq_notify_on_commit = false;
 	ut_a(trx->error_state == DB_SUCCESS);


### PR DESCRIPTION
Fixes intermittent failures in `verify_vtq()`.