### PR TITLE
SQL: WITHOUT SYSTEM VERSIONING requires hidden sys_trx fields [closes #211]

### DIFF
--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -57,6 +57,7 @@ t	CREATE TABLE `t` (
   `trx_end` timestamp(6) GENERATED ALWAYS AS ROW END,
   PERIOD FOR SYSTEM_TIME (`trx_start`, `trx_end`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+alter table t drop column trx_start, drop column trx_end;
 alter table t without system versioning;
 show create table t;
 Table	Create Table
@@ -338,6 +339,7 @@ t	CREATE TABLE `t` (
   `trx_end` bigint(20) unsigned GENERATED ALWAYS AS ROW END,
   PERIOD FOR SYSTEM_TIME (`trx_start`, `trx_end`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+alter table t drop column trx_start, drop column trx_end;
 alter table t without system versioning;
 alter table t with system versioning, algorithm=copy;
 show create table t;
@@ -511,6 +513,30 @@ period for system_time(sys_trx_start, sys_trx_end)
 ) with system versioning engine myisam;
 alter table t change column sys_trx_start asdf timestamp(6);
 ERROR HY000: Can not change system versioning field 'sys_trx_start'
+create or replace table t (
+a int,
+sys_trx_start timestamp(6) generated always as row start,
+sys_trx_end timestamp(6) generated always as row end,
+period for system_time(sys_trx_start, sys_trx_end)
+) with system versioning;
+select * from t;
+a	sys_trx_start	sys_trx_end
+alter table t without system versioning;
+ERROR HY000: System versioning field 'sys_trx_start' is not hidden
+alter table t drop column sys_trx_start;
+select * from t;
+a	sys_trx_end
+alter table t without system versioning;
+ERROR HY000: System versioning field 'sys_trx_end' is not hidden
+alter table t drop column sys_trx_end;
+select * from t;
+a
+alter table t without system versioning;
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
 call verify_vtq;
 No	A	B	C	D
 1	1	1	1	1

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -240,6 +240,27 @@ create or replace table t (
 --error ER_VERS_ALTER_SYSTEM_FIELD
 alter table t change column sys_trx_start asdf timestamp(6);
 
+create or replace table t (
+  a int,
+  sys_trx_start timestamp(6) generated always as row start,
+  sys_trx_end timestamp(6) generated always as row end,
+  period for system_time(sys_trx_start, sys_trx_end)
+) with system versioning;
+select * from t;
+
+--error ER_VERS_SYS_FIELD_NOT_HIDDEN
+alter table t without system versioning;
+alter table t drop column sys_trx_start;
+select * from t;
+
+--error ER_VERS_SYS_FIELD_NOT_HIDDEN
+alter table t without system versioning;
+alter table t drop column sys_trx_end;
+select * from t;
+
+alter table t without system versioning;
+show create table t;
+
 call verify_vtq;
 drop table t;
 

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -41,6 +41,7 @@ alter table t
   with system versioning;
 show create table t;
 
+alter table t drop column trx_start, drop column trx_end;
 alter table t without system versioning;
 show create table t;
 
@@ -150,6 +151,7 @@ alter table t
   add period for system_time(trx_start, trx_end),
   with system versioning;
 show create table t;
+alter table t drop column trx_start, drop column trx_end;
 alter table t without system versioning;
 
 alter table t with system versioning, algorithm=copy;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6814,6 +6814,7 @@ static bool add_field_to_drop_list(THD *thd, Alter_info *alter_info,
 {
   DBUG_ASSERT(field);
   DBUG_ASSERT(field->field_name);
+  alter_info->flags|= Alter_info::ALTER_DROP_COLUMN;
   Alter_drop *ad= new (thd->mem_root)
       Alter_drop(Alter_drop::COLUMN, field->field_name, false);
   return !ad || alter_info->drop_list.push_back(ad, thd->mem_root);
@@ -6838,11 +6839,23 @@ bool Vers_parse_info::check_and_fix_alter(THD *thd, Alter_info *alter_info,
       return true;
     }
 
+    if (!(share->vers_start_field()->flags & HIDDEN_FLAG))
+    {
+      my_error(ER_VERS_SYS_FIELD_NOT_HIDDEN, MYF(0),
+               share->vers_start_field()->field_name);
+      return true;
+    }
+    if (!(share->vers_end_field()->flags & HIDDEN_FLAG))
+    {
+      my_error(ER_VERS_SYS_FIELD_NOT_HIDDEN, MYF(0),
+               share->vers_end_field()->field_name);
+      return true;
+    }
+
     if (add_field_to_drop_list(thd, alter_info, share->vers_start_field()) ||
         add_field_to_drop_list(thd, alter_info, share->vers_end_field()))
       return true;
 
-    alter_info->flags|= Alter_info::ALTER_DROP_COLUMN;
     return false;
   }
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6662,7 +6662,6 @@ static bool vers_change_sys_field(THD *thd, const char *field_name,
   return false;
 }
 
-
 bool Vers_parse_info::fix_implicit(THD *thd, Alter_info *alter_info,
                                    bool integer_fields)
 {

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6955,37 +6955,14 @@ bool Vers_parse_info::check_and_fix_alter(THD *thd, Alter_info *alter_info,
           return true;
         }
 
+        it.remove();
+
         if (done_start && done_end)
           break;
       }
-
-      if (done_start)
-      {
-        List_iterator<Alter_drop> it(alter_info->drop_list);
-        while (Alter_drop *d= it++)
-        {
-          if (is_trx_start(d->name))
-          {
-            it.remove();
-            break;
-          }
-        }
-      }
-      if (done_end)
-      {
-        List_iterator<Alter_drop> it(alter_info->drop_list);
-        while (Alter_drop *d= it++)
-        {
-          if (is_trx_end(d->name))
-          {
-            it.remove();
-            break;
-          }
-        }
-      }
-
-      return false;
     }
+
+    return false;
   }
 
   return fix_implicit(thd, alter_info, integer_fields) ||

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7594,3 +7594,6 @@ ER_WRONG_TABLESPACE_NAME 42000
 
 ER_VERS_ALTER_SYSTEM_FIELD
         eng "Can not change system versioning field '%s'"
+
+ER_VERS_SYS_FIELD_NOT_HIDDEN
+	eng "System versioning field '%s' is not hidden"


### PR DESCRIPTION
Also fixes a bug introduced by https://github.com/tempesta-tech/mariadb/commit/229c528110ecb38f379a6328b0eb62f6bbc74fad
Now system field drop is a `CHANGE` and not `DROP + ADD`.