### PR TITLE
SQL: allow PERIOD as identifier [fixes #331]

### DIFF
--- a/mysql-test/extra/binlog_tests/blackhole.test
+++ b/mysql-test/extra/binlog_tests/blackhole.test
@@ -17,13 +17,13 @@ drop table if exists t1,t2;
 --enable_warnings
 
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE=blackhole;
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ from t1;
+select period from t1;
 select * from t1;
 select t1.* from t1;
 

--- a/mysql-test/include/common-tests.inc
+++ b/mysql-test/include/common-tests.inc
@@ -14,13 +14,13 @@ drop table if exists t1,t2,t3,t4;
 --enable_warnings
 
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ from t1;
+select period from t1;
 select * from t1;
 select t1.* from t1;
 
@@ -1349,7 +1349,7 @@ select fld1,fld3 from t2 where fld1 like "25050_";
 select distinct companynr from t2;
 select distinct companynr from t2 order by companynr;
 select distinct companynr from t2 order by companynr desc;
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
 
 select distinct fld3 from t2 where companynr = 34 order by fld3;
 select distinct fld3 from t2 limit 10;
@@ -1362,26 +1362,26 @@ select distinct substring(fld3,1,3) as a from t2 having a like "A%" limit 10;
 # make a big table.
 
 create table t3 (
- period_   int not null,
+ period    int not null,
  name      char(32) not null,
  companynr int not null,
  price     double(11,0),
  price2     double(11,0),
- key (period_),
+ key (period),
  key (name)
 );
 
 --disable_query_log
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1001,"Iranizes",37,5987435,234724);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1002,"violinist",37,28357832,8723648);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1003,"extramarital",37,39654943,235872);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1004,"spates",78,726498,72987523);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1005,"cloakroom",78,98439034,823742);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1006,"gazer",101,834598,27348324);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1007,"hand",154,983543950,29837423);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1008,"tucked",311,234298,3275892);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1009,"gems",447,2374834,9872392);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1010,"clinker",512,786542,76234234);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1001,"Iranizes",37,5987435,234724);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1002,"violinist",37,28357832,8723648);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1003,"extramarital",37,39654943,235872);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1004,"spates",78,726498,72987523);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1005,"cloakroom",78,98439034,823742);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1006,"gazer",101,834598,27348324);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1007,"hand",154,983543950,29837423);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1008,"tucked",311,234298,3275892);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1009,"gems",447,2374834,9872392);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1010,"clinker",512,786542,76234234);
 --enable_query_log
 
 create temporary table tmp engine = myisam select * from t3;
@@ -1450,39 +1450,39 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 # Some test with ORDER BY and limit
 #
 
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 
 #
 # Search with a constant table.
 #
 
-select period_ from t1;
-select period_ from t1 where period_=1900;
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
+select period from t1;
+select period from t1 where period=1900;
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
 
 #
 # Search with a constant table and several keyparts. (Rows are read only once
 # in the beginning of the search)
 #
 
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
 
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 
 #
 # Search with a constant table and several rows from another table
 #
 
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
+select fld3,period from t2,t1 where companynr*10 = 37*10;
 
 #
 # Search with a table reference and without a key.
 # t3 will be the main table.
 #
 
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
 
 #
 # Search with an interval on a table with full key on reference table.
@@ -1490,7 +1490,7 @@ select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >=
 # t2nr will be checked.
 #
 
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
 
 #
 # We need another table for join stuff..
@@ -1588,18 +1588,18 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 # each record
 #
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
 
 #
 # Test of many parenthesis levels
 #
 
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
 
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 
@@ -1657,7 +1657,7 @@ select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 grou
 # Calculation with group functions
 #
 
-select sum(Period_)/count(*) from t1;
+select sum(Period)/count(*) from t1;
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 select companynr,sum(price)/count(price) as avg from t3 group by companynr having avg > 70000000 order by avg;
 
@@ -1747,13 +1747,13 @@ select max(t2nr) from t3 where price=983543950;
 # Test of alias
 #
 
-select t1.period_ from t3 = t1 limit 1;
-select t1.period_ from t1 as t1 limit 1;
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-select period_ as ok_period from t1 limit 1;
-select period_ as ok_period from t1 group by ok_period limit 1;
+select t1.period from t3 = t1 limit 1;
+select t1.period from t1 as t1 limit 1;
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+select period as ok_period from t1 limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 select 1+1 as summa from t1 group by summa limit 1;
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
 
 #
 # Some simple show commands

--- a/mysql-test/r/compress.result
+++ b/mysql-test/r/compress.result
@@ -7,18 +7,18 @@ VARIABLE_NAME	VARIABLE_VALUE
 COMPRESSION	ON
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -282,8 +282,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -487,12 +487,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -606,35 +606,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1223,8 +1223,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1284,8 +1284,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1325,7 +1325,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1440,23 +1440,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1713,8 +1713,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2044,26 +2044,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/named_pipe.result
+++ b/mysql-test/r/named_pipe.result
@@ -1,18 +1,18 @@
 connect pipe_con,localhost,root,,,,,PIPE;
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -276,8 +276,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -481,12 +481,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -600,35 +600,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1217,8 +1217,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1278,8 +1278,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1319,7 +1319,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1434,23 +1434,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1707,8 +1707,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2038,26 +2038,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/pool_of_threads.result
+++ b/mysql-test/r/pool_of_threads.result
@@ -2,18 +2,18 @@ SET @save_optimizer_switch=@@optimizer_switch;
 SET optimizer_switch='outer_join_with_cache=off';
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -277,8 +277,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -482,12 +482,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -601,35 +601,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1218,8 +1218,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1279,8 +1279,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1320,7 +1320,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1435,23 +1435,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1708,8 +1708,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2039,26 +2039,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/select.result
+++ b/mysql-test/r/select.result
@@ -5,18 +5,18 @@ SET @save_optimizer_switch=@@optimizer_switch;
 SET optimizer_switch=ifnull(@optimizer_switch_for_select_test,'outer_join_with_cache=off');
 set join_cache_level=1;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -280,8 +280,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -485,12 +485,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -604,35 +604,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1221,8 +1221,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1282,8 +1282,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1323,7 +1323,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1435,23 +1435,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1708,8 +1708,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2039,26 +2039,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/select_jcl6.result
+++ b/mysql-test/r/select_jcl6.result
@@ -16,18 +16,18 @@ SET @save_optimizer_switch=@@optimizer_switch;
 SET optimizer_switch=ifnull(@optimizer_switch_for_select_test,'outer_join_with_cache=off');
 set join_cache_level=@join_cache_level_for_select_test;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -291,8 +291,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -496,12 +496,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -615,35 +615,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using temporary; Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using temporary; Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	ALL	period_	NULL	NULL	NULL	41810	Using temporary; Using filesort
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	ALL	period	NULL	NULL	NULL	41810	Using temporary; Using filesort
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using temporary; Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
-select period_ from t1;
-period_
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using temporary; Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	Using join buffer (flat, BKA join); Key-ordered Rowid-ordered scan
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1232,8 +1232,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1293,8 +1293,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1334,7 +1334,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1446,23 +1446,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	hash_ALL	NULL	#hash#$hj	1	func	1199	Using where; Using join buffer (flat, BNLH join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1719,8 +1719,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2050,26 +2050,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/select_pkeycache.result
+++ b/mysql-test/r/select_pkeycache.result
@@ -5,18 +5,18 @@ SET @save_optimizer_switch=@@optimizer_switch;
 SET optimizer_switch=ifnull(@optimizer_switch_for_select_test,'outer_join_with_cache=off');
 set join_cache_level=1;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -280,8 +280,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -485,12 +485,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -604,35 +604,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1221,8 +1221,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1282,8 +1282,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1323,7 +1323,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1435,23 +1435,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1708,8 +1708,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2039,26 +2039,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/shm.result
+++ b/mysql-test/r/shm.result
@@ -1,18 +1,18 @@
 connect shm_con,localhost,root,,,,$shm_name,SHM;
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -276,8 +276,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -481,12 +481,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -600,35 +600,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1217,8 +1217,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1278,8 +1278,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1319,7 +1319,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1434,23 +1434,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1707,8 +1707,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2038,26 +2038,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/ssl.result
+++ b/mysql-test/r/ssl.result
@@ -10,18 +10,18 @@ Variable_name	Value
 Ssl_server_not_after	Apr 20 20:52:21 2037 GMT
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -285,8 +285,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -490,12 +490,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -609,35 +609,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1226,8 +1226,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1287,8 +1287,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1328,7 +1328,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1443,23 +1443,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1716,8 +1716,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2047,26 +2047,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/r/ssl_compress.result
+++ b/mysql-test/r/ssl_compress.result
@@ -7,18 +7,18 @@ Variable_name	Value
 Compression	ON
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null auto_increment,
@@ -282,8 +282,8 @@ companynr
 34
 29
 00
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
-fld3	period_
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
+fld3	period
 obliterates	9410
 offload	9410
 opaquely	9410
@@ -487,12 +487,12 @@ acu
 Ade
 adj
 create table t3 (
-period_   int not null,
+period    int not null,
 name      char(32) not null,
 companynr int not null,
 price     double(11,0),
 price2     double(11,0),
-key (period_),
+key (period),
 key (name)
 );
 create temporary table tmp engine = myisam select * from t3;
@@ -606,35 +606,35 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	ALL	fld1	NULL	NULL	NULL	1199	Using where; Using temporary; Using filesort
 1	SIMPLE	t3	eq_ref	PRIMARY	PRIMARY	4	test.t2.fld1	1	Using where; Using index
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	period_	NULL	NULL	NULL	41810	Using filesort
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
+1	SIMPLE	t1	ALL	period	NULL	NULL	NULL	41810	Using filesort
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	period_	period_	4	NULL	1	
-1	SIMPLE	t1	ref	period_	period_	4	test.t3.period_	4181	
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+1	SIMPLE	t3	index	period	period	4	NULL	1	
+1	SIMPLE	t1	ref	period	period	4	test.t3.period	4181	
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	period_	period_	4	NULL	1	
-1	SIMPLE	t3	ref	period_	period_	4	test.t1.period_	4181	
-select period_ from t1;
-period_
+1	SIMPLE	t1	index	period	period	4	NULL	1	
+1	SIMPLE	t3	ref	period	period	4	test.t1.period	4181	
+select period from t1;
+period
 9410
-select period_ from t1 where period_=1900;
-period_
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
-fld3	period_
+select period from t1 where period=1900;
+period
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
+fld3	period
 breaking	9410
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
-fld3	period_
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
+fld3	period
 breaking	1001
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	fld1	fld1	4	const	1	
-1	SIMPLE	t3	const	PRIMARY,period_	PRIMARY	4	const	1	
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
-fld3	period_
+1	SIMPLE	t3	const	PRIMARY,period	PRIMARY	4	const	1	
+select fld3,period from t2,t1 where companynr*10 = 37*10;
+fld3	period
 breaking	9410
 Romans	9410
 intercepted	9410
@@ -1223,8 +1223,8 @@ dusted	9410
 encompasses	9410
 presentation	9410
 Kantian	9410
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
-fld3	period_	price	price2
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
+fld3	period	price	price2
 admonishing	1002	28357832	8723648
 analyzable	1002	28357832	8723648
 annihilates	1001	5987435	234724
@@ -1284,8 +1284,8 @@ ventilate	1001	5987435	234724
 wallet	1001	5987435	234724
 Weissmuller	1002	28357832	8723648
 Wotan	1002	28357832	8723648
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
-fld1	fld3	period_	price	price2
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
+fld1	fld3	period	price	price2
 018201	relaxing	1001	5987435	234724
 018601	vacuuming	1001	5987435	234724
 018801	inch	1001	5987435	234724
@@ -1325,7 +1325,7 @@ companynr	companyname
 65	company 9
 68	company 10
 select * from t1,t1 t12;
-Period_	Varor_period	Period_	Varor_period
+Period	Varor_period	Period	Varor_period
 9410	9412	9410	9412
 select t2.fld1,t22.fld1 from t2,t2 t22 where t2.fld1 >= 250501 and t2.fld1 <= 250505 and t22.fld1 >= 250501 and t22.fld1 <= 250505;
 fld1	fld1
@@ -1440,23 +1440,23 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t4	index	NULL	PRIMARY	1	NULL	12	Using index; Using temporary
 1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	1199	Using where; Using join buffer (flat, BNL join)
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
-fld1	companynr	fld3	period_
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
+fld1	companynr	fld3	period
 038008	37	reporters	1008
 038208	37	Selfridge	1008
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-period_
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+period
 9410
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
-period_
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
+period
 9410
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 fld1
@@ -1713,8 +1713,8 @@ companynr	companyname	count(*)
 select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 group by t3.name;
 fld1	count(*)
 158402	4181
-select sum(Period_)/count(*) from t1;
-sum(Period_)/count(*)
+select sum(Period)/count(*) from t1;
+sum(Period)/count(*)
 9410.0000
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 companynr	count	sum	diff	func
@@ -2044,26 +2044,26 @@ t2nr	count(*)
 select max(t2nr) from t3 where price=983543950;
 max(t2nr)
 41807
-select t1.period_ from t3 = t1 limit 1;
-period_
+select t1.period from t3 = t1 limit 1;
+period
 1001
-select t1.period_ from t1 as t1 limit 1;
-period_
+select t1.period from t1 as t1 limit 1;
+period
 9410
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-Nuvarande period_
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+Nuvarande period
 9410
-select period_ as ok_period from t1 limit 1;
+select period as ok_period from t1 limit 1;
 ok_period
 9410
-select period_ as ok_period from t1 group by ok_period limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 ok_period
 9410
 select 1+1 as summa from t1 group by summa limit 1;
 summa
 2
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
-Nuvarande period_
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
+Nuvarande period
 9410
 show tables;
 Tables_in_test

--- a/mysql-test/suite/archive/archive.result
+++ b/mysql-test/suite/archive/archive.result
@@ -3,18 +3,18 @@ call mtr.add_suppression("Table 't1' is marked as crashed and should be repaired
 DROP TABLE if exists t1,t2,t3,t4,t5,t6;
 SET storage_engine=ARCHIVE;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE=archive;
 INSERT INTO t1 VALUES (9410,9412);
-select period_ FROM t1;
-period_
+select period FROM t1;
+period
 9410
 select * FROM t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* FROM t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int,

--- a/mysql-test/suite/archive/archive.test
+++ b/mysql-test/suite/archive/archive.test
@@ -15,13 +15,13 @@ SET storage_engine=ARCHIVE;
 let $MYSQLD_DATADIR= `SELECT @@datadir`;
 
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE=archive;
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ FROM t1;
+select period FROM t1;
 select * FROM t1;
 select t1.* FROM t1;
 

--- a/mysql-test/suite/binlog/r/binlog_stm_blackhole.result
+++ b/mysql-test/suite/binlog/r/binlog_stm_blackhole.result
@@ -1,16 +1,16 @@
 CALL mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
 drop table if exists t1,t2;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE=blackhole;
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 CREATE TABLE t2 (
 auto int NOT NULL auto_increment,
 fld1 int(6) unsigned zerofill DEFAULT '000000' NOT NULL,

--- a/mysql-test/suite/csv/csv.result
+++ b/mysql-test/suite/csv/csv.result
@@ -3,18 +3,18 @@ call mtr.add_suppression("Table 'test_repair_table4' is marked as crashed and sh
 call mtr.add_suppression("Table 't1' is marked as crashed and should be repaired");
 drop table if exists t1,t2,t3,t4;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE = CSV;
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 select * from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 select t1.* from t1;
-Period_	Varor_period
+Period	Varor_period
 9410	9412
 CREATE TABLE t2 (
 auto int not null,
@@ -4919,12 +4919,12 @@ DROP TABLE t1;
 ALTER TABLE t2 RENAME t1;
 DROP TABLE t1;
 CREATE TABLE t1 (
-Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
 Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE = CSV;
 INSERT INTO t1 VALUES (9410,9412);
-select period_ from t1;
-period_
+select period from t1;
+period
 9410
 drop table if exists t1,t2,t3,t4;
 Warnings:

--- a/mysql-test/suite/csv/csv.test
+++ b/mysql-test/suite/csv/csv.test
@@ -17,13 +17,13 @@ drop table if exists t1,t2,t3,t4;
 --enable_warnings
 
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE = CSV;
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ from t1;
+select period from t1;
 select * from t1;
 select t1.* from t1;
 
@@ -1308,13 +1308,13 @@ ALTER TABLE t2 RENAME t1;
 
 DROP TABLE t1;
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 ) ENGINE = CSV;
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ from t1;
+select period from t1;
 
 drop table if exists t1,t2,t3,t4;
 

--- a/mysql-test/t/select.test
+++ b/mysql-test/t/select.test
@@ -25,13 +25,13 @@ if (`select @join_cache_level_for_select_test is not null`)
 }
 
 CREATE TABLE t1 (
-  Period_ smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
+  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
   Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
 );
 
 INSERT INTO t1 VALUES (9410,9412);
   
-select period_ from t1;
+select period from t1;
 select * from t1;
 select t1.* from t1;
 
@@ -1361,7 +1361,7 @@ select fld1,fld3 from t2 where fld1 like "25050_";
 select distinct companynr from t2;
 select distinct companynr from t2 order by companynr;
 select distinct companynr from t2 order by companynr desc;
-select distinct t2.fld3,period_ from t2,t1 where companynr=37 and fld3 like "O%";
+select distinct t2.fld3,period from t2,t1 where companynr=37 and fld3 like "O%";
 
 select distinct fld3 from t2 where companynr = 34 order by fld3;
 select distinct fld3 from t2 limit 10;
@@ -1374,26 +1374,26 @@ select distinct substring(fld3,1,3) as a from t2 having a like "A%" limit 10;
 # make a big table.
 
 create table t3 (
- period_   int not null,
+ period    int not null,
  name      char(32) not null,
  companynr int not null,
  price     double(11,0),
  price2     double(11,0),
- key (period_),
+ key (period),
  key (name)
 );
 
 --disable_query_log
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1001,"Iranizes",37,5987435,234724);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1002,"violinist",37,28357832,8723648);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1003,"extramarital",37,39654943,235872);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1004,"spates",78,726498,72987523);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1005,"cloakroom",78,98439034,823742);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1006,"gazer",101,834598,27348324);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1007,"hand",154,983543950,29837423);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1008,"tucked",311,234298,3275892);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1009,"gems",447,2374834,9872392);
-INSERT INTO t3 (period_,name,companynr,price,price2) VALUES (1010,"clinker",512,786542,76234234);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1001,"Iranizes",37,5987435,234724);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1002,"violinist",37,28357832,8723648);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1003,"extramarital",37,39654943,235872);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1004,"spates",78,726498,72987523);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1005,"cloakroom",78,98439034,823742);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1006,"gazer",101,834598,27348324);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1007,"hand",154,983543950,29837423);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1008,"tucked",311,234298,3275892);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1009,"gems",447,2374834,9872392);
+INSERT INTO t3 (period,name,companynr,price,price2) VALUES (1010,"clinker",512,786542,76234234);
 --enable_query_log
 
 create temporary table tmp engine = myisam select * from t3;
@@ -1462,39 +1462,39 @@ explain select t3.t2nr,fld3 from t2,t3 where t2.companynr = 34 and t2.fld1=t3.t2
 # Some test with ORDER BY and limit
 #
 
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_;
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t3.period_ limit 10;
-explain select * from t3 as t1,t3 where t1.period_=t3.period_ order by t1.period_ limit 10;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t3.period limit 10;
+explain select * from t3 as t1,t3 where t1.period=t3.period order by t1.period limit 10;
 
 #
 # Search with a constant table.
 #
 
-select period_ from t1;
-select period_ from t1 where period_=1900;
-select fld3,period_ from t1,t2 where fld1 = 011401 order by period_;
+select period from t1;
+select period from t1 where period=1900;
+select fld3,period from t1,t2 where fld1 = 011401 order by period;
 
 #
 # Search with a constant table and several keyparts. (Rows are read only once
 # in the beginning of the search)
 #
 
-select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period_=1001;
+select fld3,period from t2,t3 where t2.fld1 = 011401 and t2.fld1=t3.t2nr and t3.period=1001;
 
-explain select fld3,period_ from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period_;
+explain select fld3,period from t2,t3 where t2.fld1 = 011401 and t3.t2nr=t2.fld1 and 1001 = t3.period;
 
 #
 # Search with a constant table and several rows from another table
 #
 
-select fld3,period_ from t2,t1 where companynr*10 = 37*10;
+select fld3,period from t2,t1 where companynr*10 = 37*10;
 
 #
 # Search with a table reference and without a key.
 # t3 will be the main table.
 #
 
-select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >= 1001 and period_ <= 1002 and t2.companynr = 37 order by fld3,period_, price;
+select fld3,period,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period >= 1001 and period <= 1002 and t2.companynr = 37 order by fld3,period, price;
 
 #
 # Search with an interval on a table with full key on reference table.
@@ -1502,7 +1502,7 @@ select fld3,period_,price,price2 from t2,t3 where t2.fld1=t3.t2nr and period_ >=
 # t2nr will be checked.
 #
 
-select t2.fld1,fld3,period_,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period_ = 1001 and t2.companynr = 37;
+select t2.fld1,fld3,period,price,price2 from t2,t3 where t2.fld1>= 18201 and t2.fld1 <= 18811 and t2.fld1=t3.t2nr and period = 1001 and t2.companynr = 37;
 
 #
 # We need another table for join stuff..
@@ -1594,18 +1594,18 @@ explain select distinct t2.companynr,t4.companynr from t2,t4 where t2.companynr=
 # each record
 #
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period_ = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period_ = 1008;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where t2.fld1 = 38208 and t2.fld1=t3.t2nr and period = 1008 or t2.fld1 = 38008 and t2.fld1 =t3.t2nr and period = 1008;
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t2.fld1 = 38208 or t2.fld1 = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
 
-select t2.fld1,t2.companynr,fld3,period_ from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period_>=1008 and period_<=1009;
+select t2.fld1,t2.companynr,fld3,period from t3,t2 where (t3.t2nr = 38208 or t3.t2nr = 38008) and t2.fld1=t3.t2nr and period>=1008 and period<=1009;
 
 #
 # Test of many parenthesis levels
 #
 
-select period_ from t1 where (((period_ > 0) or period_ < 10000 or (period_ = 1900)) and (period_=1900 and period_ <= 1901) or (period_=1903 and (period_=1903)) and period_>=1902) or ((period_=1904 or period_=1905) or (period_=1906 or period_>1907)) or (period_=1908 and period_ = 1909);
-select period_ from t1 where ((period_ > 0 and period_ < 1) or (((period_ > 0 and period_ < 100) and (period_ > 10)) or (period_ > 10)) or (period_ > 0 and (period_ > 5 or period_ > 6)));
+select period from t1 where (((period > 0) or period < 10000 or (period = 1900)) and (period=1900 and period <= 1901) or (period=1903 and (period=1903)) and period>=1902) or ((period=1904 or period=1905) or (period=1906 or period>1907)) or (period=1908 and period = 1909);
+select period from t1 where ((period > 0 and period < 1) or (((period > 0 and period < 100) and (period > 10)) or (period > 10)) or (period > 0 and (period > 5 or period > 6)));
 
 select a.fld1 from t2 as a,t2 b where ((a.fld1 = 250501 and a.fld1=b.fld1) or a.fld1=250502 or a.fld1=250503 or (a.fld1=250505 and a.fld1<=b.fld1 and b.fld1>=a.fld1)) and a.fld1=b.fld1;
 
@@ -1663,7 +1663,7 @@ select t2.fld1,count(*) from t2,t3 where t2.fld1=158402 and t3.name=t2.fld3 grou
 # Calculation with group functions
 #
 
-select sum(Period_)/count(*) from t1;
+select sum(Period)/count(*) from t1;
 select companynr,count(price) as "count",sum(price) as "sum" ,abs(sum(price)/count(price)-avg(price)) as "diff",(0+count(price))*companynr as func from t3 group by companynr;
 select companynr,sum(price)/count(price) as avg from t3 group by companynr having avg > 70000000 order by avg;
 
@@ -1753,13 +1753,13 @@ select max(t2nr) from t3 where price=983543950;
 # Test of alias
 #
 
-select t1.period_ from t3 = t1 limit 1;
-select t1.period_ from t1 as t1 limit 1;
-select t1.period_ as "Nuvarande period_" from t1 as t1 limit 1;
-select period_ as ok_period from t1 limit 1;
-select period_ as ok_period from t1 group by ok_period limit 1;
+select t1.period from t3 = t1 limit 1;
+select t1.period from t1 as t1 limit 1;
+select t1.period as "Nuvarande period" from t1 as t1 limit 1;
+select period as ok_period from t1 limit 1;
+select period as ok_period from t1 group by ok_period limit 1;
 select 1+1 as summa from t1 group by summa limit 1;
-select period_ as "Nuvarande period_" from t1 group by "Nuvarande period_" limit 1;
+select period as "Nuvarande period" from t1 group by "Nuvarande period" limit 1;
 
 #
 # Some simple show commands

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -871,10 +871,10 @@ bool my_yyoverflow(short **a, YYSTYPE **b, ulong *yystacksize);
 %parse-param { THD *thd }
 %lex-param { THD *thd }
 /*
-  Currently there are 115 shift/reduce conflicts.
+  Currently there are 117 shift/reduce conflicts.
   We should not introduce new conflicts any more.
 */
-%expect 115
+%expect 117
 
 /*
    Comments for TOKENS.
@@ -15074,6 +15074,7 @@ keyword:
         | OTHERS_SYM            {}
         | OWNER_SYM             {}
         | PARSER_SYM            {}
+        | PERIOD_SYM            {}
         | PORT_SYM              {}
         | PRECEDES_SYM          {}
         | PRECEDING_SYM         {}


### PR DESCRIPTION
Fixes this test case:
https://github.com/MariaDB/server/blob/10.3/mysql-test/t/select.test
```sql
CREATE TABLE t1 (
  Period smallint(4) unsigned zerofill DEFAULT '0000' NOT NULL,
  Varor_period smallint(4) unsigned DEFAULT '0' NOT NULL
);
```