### PR TITLE
Remove the flag vers_update_trt (#339)

### DIFF
--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -344,7 +344,6 @@ add period for system_time(trx_start, trx_end),
 add system versioning;
 call verify_vtq;
 No	A	B	C	D
-1	1	1	1	1
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
@@ -362,7 +361,6 @@ No	A	B	C	D
 alter table t add system versioning, algorithm=copy;
 call verify_vtq;
 No	A	B	C	D
-1	1	1	1	1
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
@@ -415,7 +413,6 @@ No	A	B	C	D
 alter table t add system versioning, algorithm=inplace;
 call verify_vtq;
 No	A	B	C	D
-1	1	1	1	1
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -219,7 +219,13 @@ create or replace table t (a int) with system versioning engine=innodb;
 insert into t values (1), (2), (3);
 delete from t where a<3;
 call verify_vtq;
+--disable_query_log
+set global versioning_asof_timestamp= all;
+--enable_query_log
 alter table t add b tinyint auto_increment unique;
+--disable_query_log
+set global versioning_asof_timestamp= current;
+--enable_query_log
 call verify_vtq;
 select * from t for system_time all;
 insert into t values (4, NULL);

--- a/mysql-test/suite/versioning/t/commit_id.test
+++ b/mysql-test/suite/versioning/t/commit_id.test
@@ -10,6 +10,7 @@ engine innodb;
 
 insert into t1 values ();
 
+--real_sleep 0.01
 set @ts0= now(6);
 insert into t1 values ();
 select sys_trx_start from t1 where id = last_insert_id() into @tx0;

--- a/mysys/my_error.c
+++ b/mysys/my_error.c
@@ -70,10 +70,15 @@ static struct my_err_head *my_errmsgs_list= &my_errmsgs_globerrs;
   @retval str   C-string
 */
 
+void (*mega_assert)(uint)= 0;
+
 const char *my_get_err_msg(uint nr)
 {
   const char *format;
   struct my_err_head *meh_p;
+
+  if (mega_assert)
+    mega_assert(nr);
 
   /* Search for the range this error is in. */
   for (meh_p= my_errmsgs_list; meh_p; meh_p= meh_p->meh_next)

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -980,7 +980,6 @@ struct handler_iterator {
 class handler;
 class group_by_handler;
 struct Query;
-class TR_table;
 typedef class st_select_lex SELECT_LEX;
 typedef struct st_order ORDER;
 
@@ -1390,10 +1389,12 @@ struct handlerton
    /*
      System Versioning
    */
-   /** Fill TRT record for update.
-    @param[out]   trt       TRT table which record[0] will be filled with
-                            transaction data. */
-   void (*vers_get_trt_data)(TR_table &trt);
+   /** Determine if system-versioned data was modified by the transaction.
+   @param[in,out] thd          current session
+   @param[out]    trx_id       transaction start ID
+   @return transaction commit ID
+   @retval 0 if no system-versioned data was affected by the transaction */
+   ulonglong (*prepare_commit_versioned)(THD *thd, ulonglong *trx_id);
 };
 
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5712,6 +5712,9 @@ static void test_lc_time_sz()
 #endif//DBUG_OFF
 
 
+extern void super_assert(uint nr);
+extern void (*mega_assert)(uint);
+
 #ifdef __WIN__
 int win_main(int argc, char **argv)
 #else
@@ -6058,6 +6061,8 @@ int mysqld_main(int argc, char **argv)
 
   if (opt_transaction_registry && !use_transaction_registry)
     sql_print_information("Disabled transaction registry.");
+
+  mega_assert= super_assert;
 
   if (WSREP_ON)
   {

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -716,11 +716,6 @@ Time_zone * thd_get_timezone(THD * thd)
 	return thd->variables.time_zone;
 }
 
-void thd_vers_update_trt(THD * thd, bool value)
-{
-  thd->vers_update_trt= value;
-}
-
 THD::THD(my_thread_id id, bool is_wsrep_applier)
   :Statement(&main_lex, &main_mem_root, STMT_CONVENTIONAL_EXECUTION,
              /* statement id */ 0),
@@ -1352,8 +1347,6 @@ void THD::init(void)
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
 #endif /* WITH_WSREP */
-
-  vers_update_trt = false;
 
   if (variables.sql_log_bin)
     variables.option_bits|= OPTION_BIN_LOG;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -7720,3 +7720,11 @@ Query_arena_stmt::~Query_arena_stmt()
   if (arena)
     thd->restore_active_arena(arena, &backup);
 }
+
+void super_assert(uint nr)
+{
+  if (global_system_variables.vers_asof_timestamp.type > 0)
+  {
+    DBUG_ASSERT(nr != ER_WARN_DATA_OUT_OF_RANGE);
+  }
+}

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4564,8 +4564,6 @@ public:
   /* Handling of timeouts for commands */
   thr_timer_t query_timer;
 
-  bool vers_update_trt;
-
 public:
   void set_query_timer()
   {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -6366,17 +6366,14 @@ field_def:
             const LEX_CSTRING &field_name= lex->last_field->field_name;
 
             LString_i *p;
-            const char* clause;
             switch ($4)
             {
             case 1:
               p= &info.as_row.start;
-              clause= "AS ROW START";
               lex->last_field->flags|= VERS_SYS_START_FLAG;
               break;
             case 0:
               p= &info.as_row.end;
-              clause= "AS ROW END";
               lex->last_field->flags|= VERS_SYS_END_FLAG;
               break;
             default:

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -8525,22 +8525,6 @@ void TR_table::store(uint field_id, timeval ts)
   table->field[field_id]->set_notnull();
 }
 
-void TR_table::store_data(ulonglong trx_id, ulonglong commit_id, timeval commit_ts)
-{
-  timeval start_time= {thd->start_time, thd->start_time_sec_part};
-  store(FLD_TRX_ID, trx_id);
-  store(FLD_COMMIT_ID, commit_id);
-  store(FLD_BEGIN_TS, start_time);
-  if (thd->start_time_ge(commit_ts.tv_sec, commit_ts.tv_usec))
-  {
-    thd->start_time_inc();
-    commit_ts.tv_sec= thd->start_time;
-    commit_ts.tv_usec= thd->start_time_sec_part;
-  }
-  store(FLD_COMMIT_TS, commit_ts);
-  store_iso_level(thd->tx_isolation);
-}
-
 enum_tx_isolation TR_table::iso_level() const
 {
   enum_tx_isolation res= (enum_tx_isolation) ((*this)[FLD_ISO_LEVEL]->val_int() - 1);
@@ -8548,24 +8532,23 @@ enum_tx_isolation TR_table::iso_level() const
   return res;
 }
 
-bool TR_table::update()
+bool TR_table::update(ulonglong start_id, ulonglong end_id)
 {
   if (!table && open())
     return true;
 
-  DBUG_ASSERT(table->s);
-  handlerton *hton= table->s->db_type();
-  DBUG_ASSERT(hton);
-  DBUG_ASSERT(hton->flags & HTON_NATIVE_SYS_VERSIONING);
-  DBUG_ASSERT(thd->vers_update_trt);
+  timeval start_time= {thd->start_time, long(thd->start_time_sec_part)};
+  thd->set_current_time();
+  timeval end_time= {thd->start_time, long(thd->start_time_sec_part)};
+  store(FLD_TRX_ID, start_id);
+  store(FLD_COMMIT_ID, end_id);
+  store(FLD_BEGIN_TS, start_time);
+  store(FLD_COMMIT_TS, end_time);
+  store_iso_level(thd->tx_isolation);
 
-  hton->vers_get_trt_data(*this);
   int error= table->file->ha_write_row(table->record[0]);
   if (error)
-  {
     table->file->print_error(error, MYF(0));
-  }
-  thd->vers_update_trt= false;
   return error;
 }
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -2958,8 +2958,15 @@ public:
   THD *get_thd() const { return thd; }
   void store(uint field_id, ulonglong val);
   void store(uint field_id, timeval ts);
-  void store_data(ulonglong trx_id, ulonglong commit_id, timeval commit_ts);
-  bool update();
+  /**
+    Update the transaction metadata right before commit.
+    @param start_id    transaction identifier at start
+    @param end_id      transaction identifier at commit
+
+    @retval false      on success
+    @retval true       on error (the transaction must be rolled back)
+  */
+  bool update(ulonglong start_id, ulonglong end_id);
   // return true if found; false if not found or error
   bool query(ulonglong trx_id);
   bool query(MYSQL_TIME &commit_time, bool backwards);

--- a/sql/vtmd.cc
+++ b/sql/vtmd.cc
@@ -255,11 +255,13 @@ err:
   }
 
 quit:
-  if (!result && use_transaction_registry)
+  if (result || !use_transaction_registry);
+  else if (ulonglong (*prepare)(THD*,ulonglong*)= vtmd.table->file->ht->
+           prepare_commit_versioned)
   {
-    DBUG_ASSERT(thd->vers_update_trt);
     TR_table trt(thd, true);
-    result= trt.update();
+    ulonglong trx_start_id, trx_end_id= prepare(thd, &trx_start_id);
+    result= trx_end_id && trt.update(trx_start_id, trx_end_id);
   }
 
   close_log_table(thd, &open_tables_backup);

--- a/storage/innobase/dict/dict0mem.cc
+++ b/storage/innobase/dict/dict0mem.cc
@@ -312,11 +312,13 @@ dict_mem_table_add_col(
 
 	dict_mem_fill_column_struct(col, i, mtype, prtype, len);
 
-	if (prtype & DATA_VERS_START) {
-		ut_ad(!(prtype & DATA_VERS_END));
+	switch (prtype & DATA_VERSIONED) {
+	case DATA_VERS_START:
+		ut_ad(!table->vers_start);
 		table->vers_start = i;
-	} else if (prtype & DATA_VERS_END) {
-		ut_ad(!(prtype & DATA_VERS_START));
+		break;
+	case DATA_VERS_END:
+		ut_ad(!table->vers_end);
 		table->vers_end = i;
 	}
 }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3623,24 +3623,37 @@ static const char* ha_innobase_exts[] = {
 	NullS
 };
 
-void innodb_get_trt_data(TR_table &trt)
+/** Determine if system-versioned data was modified by the transaction.
+@param[in,out]	thd	current session
+@param[out]	trx_id	transaction start ID
+@return	transaction commit ID
+@retval	0	if no system-versioned data was affected by the transaction */
+static ulonglong innodb_prepare_commit_versioned(THD* thd, ulonglong *trx_id)
 {
-	THD *thd = trt.get_thd();
-	trx_t *trx = thd_to_trx(thd);
-	ut_a(trx);
-	ut_a(trx->vers_update_trt);
-	mutex_enter(&trx_sys->mutex);
-	trx_id_t commit_id = trx_sys_get_new_trx_id();
-	ulint sec = 0;
-	ulint usec = 0;
-	ut_usectime(&sec, &usec);
-	mutex_exit(&trx_sys->mutex);
+	if (const trx_t* trx = thd_to_trx(thd)) {
+		*trx_id = trx->id;
 
-	// silent downgrade cast warning on win64
-	timeval commit_ts = {static_cast<int>(sec),
-				static_cast<int>(usec)};
-	trt.store_data(trx->id, commit_id, commit_ts);
-	trx->vers_update_trt = false;
+		for (trx_mod_tables_t::const_iterator t
+			     = trx->mod_tables.begin();
+		     t != trx->mod_tables.end(); t++) {
+			if (t->second.is_versioned()) {
+				DBUG_ASSERT(t->first->versioned());
+				DBUG_ASSERT(trx->undo_no);
+				DBUG_ASSERT(trx->rsegs.m_redo.rseg);
+
+				mutex_enter(&trx_sys->mutex);
+				trx_id_t commit_id = trx_sys_get_new_trx_id();
+				mutex_exit(&trx_sys->mutex);
+
+				return commit_id;
+			}
+		}
+
+		return 0;
+	}
+
+	*trx_id = 0;
+	return 0;
 }
 
 /*********************************************************************//**
@@ -3711,7 +3724,8 @@ innobase_init(
 	innobase_hton->table_options = innodb_table_option_list;
 
 	/* System Versioning */
-	innobase_hton->vers_get_trt_data = innodb_get_trt_data;
+	innobase_hton->prepare_commit_versioned
+		= innodb_prepare_commit_versioned;
 
 	innodb_remember_check_sysvar_funcs();
 
@@ -4895,8 +4909,6 @@ innobase_rollback_to_savepoint(
 
 	dberr_t	error = trx_rollback_to_savepoint_for_mysql(
 		trx, name, &mysql_binlog_cache_pos);
-
-	thd_vers_update_trt(thd, trx->vers_update_trt);
 
 	if (error == DB_SUCCESS && trx->fts_trx != NULL) {
 		fts_savepoint_rollback(trx, name);
@@ -8374,9 +8386,6 @@ no_commit:
 	/* Step-5: Execute insert graph that will result in actual insert. */
 	error = row_insert_for_mysql((byte*) record, m_prebuilt, vers_set_fields);
 
-	if (m_prebuilt->trx->vers_update_trt)
-		thd_vers_update_trt(m_user_thd, true);
-
 	DEBUG_SYNC(m_user_thd, "ib_after_row_insert");
 
 	/* Step-6: Handling of errors related to auto-increment. */
@@ -9196,9 +9205,6 @@ ha_innobase::update_row(
 			error = row_insert_for_mysql((byte*) old_row, m_prebuilt, ROW_INS_HISTORICAL);
 	}
 
-	if (m_prebuilt->trx->vers_update_trt)
-		thd_vers_update_trt(m_user_thd, true);
-
 	if (error == DB_SUCCESS && autoinc) {
 		/* A value for an AUTO_INCREMENT column
 		was specified in the UPDATE statement. */
@@ -9317,9 +9323,6 @@ ha_innobase::delete_row(
 		table->vers_end_field()->is_max();
 
 	error = row_update_for_mysql(m_prebuilt, vers_set_fields);
-
-	if (m_prebuilt->trx->vers_update_trt)
-		thd_vers_update_trt(m_user_thd, true);
 
 	innobase_srv_conc_exit_innodb(m_prebuilt);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -11408,14 +11408,16 @@ create_table_info_t::create_table_def()
 		ulint	is_virtual;
 		bool	is_stored = false;
 		Field*	field = m_form->field[i];
-		ulint vers_row_start = 0;
-		ulint vers_row_end = 0;
+		ulint vers_row = 0;
 
 		if (m_form->versioned()) {
 			if (i == m_form->s->row_start_field) {
-				vers_row_start = DATA_VERS_START;
+				vers_row = DATA_VERS_START;
 			} else if (i == m_form->s->row_end_field) {
-				vers_row_end = DATA_VERS_END;
+				vers_row = DATA_VERS_END;
+			} else if (!(field->flags
+				     & VERS_OPTIMIZED_UPDATE_FLAG)) {
+				vers_row = DATA_VERSIONED;
 			}
 		}
 
@@ -11509,7 +11511,7 @@ err_col:
 					(ulint) field->type()
 					| nulls_allowed | unsigned_type
 					| binary_type | long_true_varchar
-					| vers_row_start | vers_row_end,
+					| vers_row,
 					charset_no),
 				col_len);
 		} else {
@@ -11519,7 +11521,7 @@ err_col:
 					(ulint) field->type()
 					| nulls_allowed | unsigned_type
 					| binary_type | long_true_varchar
-					| vers_row_start | vers_row_end
+					| vers_row
 					| is_virtual,
 					charset_no),
 				col_len, i, 0);

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -586,8 +586,6 @@ bool thd_is_strict_mode(const MYSQL_THD thd);
  */
 extern void mysql_bin_log_commit_pos(THD *thd, ulonglong *out_pos, const char **out_file);
 
-extern void thd_vers_update_trt(THD * thd, bool value);
-
 /** Get the partition_info working copy.
 @param	thd	Thread object.
 @return	NULL or pointer to partition_info working copy. */

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4982,6 +4982,9 @@ new_clustered_failed:
 				} else if (i ==
 					   altered_table->s->row_end_field) {
 					field_type |= DATA_VERS_END;
+				} else if (!(field->flags
+					     & VERS_OPTIMIZED_UPDATE_FLAG)) {
+					field_type |= DATA_VERSIONED;
 				}
 			}
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -7089,9 +7089,6 @@ ok_exit:
 		ctx->m_stage, add_v, eval_table,
 		ha_alter_info->handler_flags & Alter_inplace_info::ALTER_DROP_HISTORICAL);
 
-	if (m_prebuilt->trx->vers_update_trt)
-		thd_vers_update_trt(m_user_thd, true);
-
 #ifndef DBUG_OFF
 oom:
 #endif /* !DBUG_OFF */

--- a/storage/innobase/include/data0data.h
+++ b/storage/innobase/include/data0data.h
@@ -591,6 +591,19 @@ struct dfield_t{
 	@param[in,out]	heap	memory heap in which the clone will be created
 	@return	the cloned object */
 	dfield_t* clone(mem_heap_t* heap) const;
+
+	/** @return whether this column is the end of the system
+	version history and points to the past, that is, this record
+	does not exist in the current time */
+	bool is_version_historical_end() const
+	{
+		if (!type.is_version_end()) {
+			return false;
+		}
+
+		ut_ad(len == sizeof trx_id_max_bytes);
+		return memcmp(data, trx_id_max_bytes, sizeof trx_id_max_bytes);
+	}
 };
 
 /** Structure for an SQL data tuple of fields (logical record) */

--- a/storage/innobase/include/data0type.h
+++ b/storage/innobase/include/data0type.h
@@ -192,6 +192,8 @@ be less than 256 */
 /** System Versioning */
 #define DATA_VERS_START	16384U	/* start system field */
 #define DATA_VERS_END	32768U	/* end system field */
+/** system-versioned user data column */
+#define DATA_VERSIONED (DATA_VERS_START|DATA_VERS_END)
 
 /** Check whether locking is disabled (never). */
 #define dict_table_is_locking_disabled(table) false
@@ -558,6 +560,19 @@ struct dtype_t{
 					DATA_MBMINMAXLEN(mbminlen,mbmaxlen);
 					mbminlen=DATA_MBMINLEN(mbminmaxlen);
 					mbmaxlen=DATA_MBMINLEN(mbminmaxlen) */
+
+	/** @return whether this is system versioned */
+	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
+	/** @return whether this is the system version start */
+	bool is_version_start() const
+	{
+		return (prtype & DATA_VERSIONED) == DATA_VERS_START;
+	}
+	/** @return whether this is the system version end */
+	bool is_version_end() const
+	{
+		return (prtype & DATA_VERSIONED) == DATA_VERS_END;
+	}
 };
 
 #include "data0type.ic"

--- a/storage/innobase/include/data0type.h
+++ b/storage/innobase/include/data0type.h
@@ -561,7 +561,9 @@ struct dtype_t{
 					mbminlen=DATA_MBMINLEN(mbminmaxlen);
 					mbmaxlen=DATA_MBMINLEN(mbminmaxlen) */
 
-	/** @return whether this is system versioned */
+	/** @return whether this is any system versioned field */
+	bool is_any_versioned() const { return prtype & DATA_VERSIONED; }
+	/** @return whether this is system versioned user field */
 	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
 	/** @return whether this is the system version start */
 	bool is_version_start() const

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -652,6 +652,20 @@ struct dict_col_t{
 	bool is_virtual() const { return prtype & DATA_VIRTUAL; }
 	/** @return whether NULL is an allowed value for this column */
 	bool is_nullable() const { return !(prtype & DATA_NOT_NULL); }
+
+	/** @return whether this is system versioned */
+	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
+	/** @return whether this is the system version start */
+	bool is_version_start() const
+	{
+		return (prtype & DATA_VERSIONED) == DATA_VERS_START;
+	}
+	/** @return whether this is the system version end */
+	bool is_version_end() const
+	{
+		return (prtype & DATA_VERSIONED) == DATA_VERS_END;
+	}
+
 	/** @return whether this is an instantly-added column */
 	bool is_instant() const
 	{

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -653,6 +653,8 @@ struct dict_col_t{
 	/** @return whether NULL is an allowed value for this column */
 	bool is_nullable() const { return !(prtype & DATA_NOT_NULL); }
 
+	/** @return whether this is any system versioned field */
+	bool is_any_versioned() const { return prtype & DATA_VERSIONED; }
 	/** @return whether this is system versioned */
 	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
 	/** @return whether this is the system version start */

--- a/storage/innobase/include/dict0types.h
+++ b/storage/innobase/include/dict0types.h
@@ -52,6 +52,12 @@ DICT_IBUF_ID_MIN plus the space id */
 typedef ib_id_t		table_id_t;
 typedef ib_id_t		index_id_t;
 
+/** Maximum transaction identifier */
+#define TRX_ID_MAX	IB_ID_MAX
+
+/** The bit pattern corresponding to TRX_ID_MAX */
+extern const char trx_id_max_bytes[8];
+
 /** Error to ignore when we load table dictionary into memory. However,
 the table and index will be marked as "corrupted", and caller will
 be responsible to deal with corrupted table or index.

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -484,6 +484,18 @@ struct upd_t{
 		return(false);
 	}
 
+	/** Determine if the update affects a system versioned column.
+	@param[in]	index	the clustered index that is being updated */
+	bool affects_versioned() const
+	{
+		for (ulint i = 0; i < n_fields; i++) {
+			if (fields[i].new_val.type.is_any_versioned()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 #ifdef UNIV_DEBUG
         bool validate() const
         {

--- a/storage/innobase/include/trx0types.h
+++ b/storage/innobase/include/trx0types.h
@@ -143,7 +143,6 @@ typedef ib_id_t	undo_no_t;
 /** Transaction savepoint */
 struct trx_savept_t{
 	undo_no_t	least_undo_no;	/*!< least undo number to undo */
-	bool		vers_update_trt; /*!< Notify TRT for System Versioned write */
 };
 
 /** File objects */

--- a/storage/innobase/include/trx0types.h
+++ b/storage/innobase/include/trx0types.h
@@ -140,9 +140,6 @@ typedef ib_id_t	roll_ptr_t;
 /** Undo number */
 typedef ib_id_t	undo_no_t;
 
-/** Maximum transaction identifier */
-#define TRX_ID_MAX	IB_ID_MAX
-
 /** Transaction savepoint */
 struct trx_savept_t{
 	undo_no_t	least_undo_no;	/*!< least undo number to undo */

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1705,13 +1705,8 @@ row_ins_check_foreign_constraint(
 		}
 		/* System Versioning: if sys_trx_end != Inf, we
 		suppress the foreign key check */
-		if (table->versioned() &&
-		    dfield_get_type(field)->prtype & DATA_VERS_END) {
-			byte* data = static_cast<byte*>(dfield_get_data(field));
-			ut_ad(data);
-			trx_id_t end_trx_id = mach_read_from_8(data);
-			if (end_trx_id != TRX_ID_MAX)
-				goto exit_func;
+		if (field->is_version_historical_end()) {
+			goto exit_func;
 		}
 	}
 

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -2328,7 +2328,6 @@ end_of_index:
 				row, new_table->vers_end);
 			dfield_set_data(start, sys_trx_start, 8);
 			dfield_set_data(end, sys_trx_end, 8);
-			trx->vers_update_trt= true;
 		}
 
 write_buffers:

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1569,10 +1569,6 @@ error_exit:
 
 	node->duplicate = NULL;
 
-	if (node->table->versioned() && ins_mode != ROW_INS_NORMAL) {
-		trx->vers_update_trt = true;
-	}
-
 	if (dict_table_has_fts_index(table)) {
 		doc_id_t	doc_id;
 
@@ -2208,14 +2204,6 @@ run_again:
 	} else {
 		/* Always update the table modification counter. */
 		prebuilt->table->stat_modified_counter++;
-	}
-
-	if (node->table->versioned() &&
-	    (node->versioned || node->vers_delete ||
-	     // TODO: improve this check (check if we touch only
-	     // unversioned fields in foreigh table)
-	     node->foreign)) {
-		trx->vers_update_trt = true;
 	}
 
 	trx->op_info = "";

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -2013,10 +2013,25 @@ trx_undo_report_row_operation(
 			mutex_exit(&trx->undo_mutex);
 
 			if (!is_temp) {
-				trx->mod_tables.insert(
-					trx_mod_tables_t::value_type(
-						index->table,
-						undo->top_undo_no));
+				const undo_no_t limit = undo->top_undo_no;
+				/* Determine if this is the first time
+				when this transaction modifies a
+				system-versioned column in this table. */
+				trx_mod_table_time_t& time
+					= trx->mod_tables.insert(
+						trx_mod_tables_t::value_type(
+							index->table, limit))
+					.first->second;
+				ut_ad(time.valid(limit));
+
+				if (!time.is_versioned()
+				    && index->table->versioned()
+				    && (!rec /* INSERT */
+					|| !update /* DELETE */
+					|| update->affects_versioned())) {
+
+					time.set_versioned(limit);
+				}
 			}
 
 			*roll_ptr = trx_undo_build_roll_ptr(

--- a/storage/innobase/trx/trx0roll.cc
+++ b/storage/innobase/trx/trx0roll.cc
@@ -130,13 +130,13 @@ trx_rollback_to_savepoint_low(
 		for (trx_mod_tables_t::iterator i = trx->mod_tables.begin();
 		     i != trx->mod_tables.end(); ) {
 			trx_mod_tables_t::iterator j = i++;
-			if (j->second >= limit) {
+			ut_ad(j->second.valid());
+			if (j->second.rollback(limit)) {
 				trx->mod_tables.erase(j);
 			}
 		}
 		trx->lock.que_state = TRX_QUE_RUNNING;
 		MONITOR_INC(MONITOR_TRX_ROLLBACK_SAVEPOINT);
-		trx->vers_update_trt = savept->vers_update_trt;
 	}
 
 	ut_a(trx->error_state == DB_SUCCESS);
@@ -626,7 +626,6 @@ trx_savept_take(
 	trx_savept_t	savept;
 
 	savept.least_undo_no = trx->undo_no;
-	savept.vers_update_trt = trx->vers_update_trt;
 
 	return(savept);
 }

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -150,8 +150,6 @@ trx_init(
 
 	trx->check_unique_secondary = true;
 
-	trx->vers_update_trt = false;
-
 	trx->lock.n_rec_locks = 0;
 
 	trx->dict_operation = TRX_DICT_OP_NONE;

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -62,6 +62,11 @@ Created 3/26/1996 Heikki Tuuri
 extern "C"
 int thd_deadlock_victim_preference(const MYSQL_THD thd1, const MYSQL_THD thd2);
 
+/** The bit pattern corresponding to TRX_ID_MAX */
+const char trx_id_max_bytes[8] = {
+	'\377', '\377', '\377', '\377', '\377', '\377', '\377', '\377'
+};
+
 static const ulint MAX_DETAILED_ERROR_LEN = 256;
 
 /** Set of table_id */


### PR DESCRIPTION
THD::vers_update_trt, trx_t::vers_update_trt, trx_savept_t::vers_update_trt:
Remove. Instead, let handlerton::prepare_commit_versioned() determine whether versioned
tables were affected.