### PR TITLE
MDEV-14627 Assertion `row_start_field' failed in vers_prepare_keys

### DIFF
--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -497,5 +497,10 @@ set versioning_alter_history= SURVIVE;
 ERROR 42000: Variable 'versioning_alter_history' can't be set to the value of 'SURVIVE'
 set versioning_alter_history= DROP;
 ERROR 42000: Variable 'versioning_alter_history' can't be set to the value of 'DROP'
+create or replace table t (a int) with system versioning;
+alter table t add system versioning;
+ERROR HY000: Table `t` is already system-versioned table
+alter table t add system versioning, drop system versioning;
+ERROR HY000: Table `t` is already system-versioned table
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -336,5 +336,11 @@ show create table t;
 call verify_vtq;
 }
 
+create or replace table t (a int) with system versioning;
+--error ER_VERS_ALREADY_VERSIONED
+alter table t add system versioning;
+--error ER_VERS_ALREADY_VERSIONED
+alter table t add system versioning, drop system versioning;
+
 drop database test;
 create database test;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7047,6 +7047,12 @@ bool Vers_parse_info::check_and_fix_alter(THD *thd, Alter_info *alter_info,
   if (!need_check() && !share->versioned)
     return false;
 
+  if (with_system_versioning && table->versioned())
+  {
+    my_error(ER_VERS_ALREADY_VERSIONED, MYF(0), table_name);
+    return true;
+  }
+
   if (without_system_versioning)
   {
     if (!share->versioned)

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7925,3 +7925,6 @@ ER_VERS_TRT_IS_DISABLED
 
 ER_VERS_DUPLICATE_ROW_START_END
 	eng "Duplicate ROW %s column %`s"
+
+ER_VERS_ALREADY_VERSIONED
+        eng "Table %`s is already system-versioned table"


### PR DESCRIPTION
> 11.29 <add system versioning clause>
> ...
> 5) T shall not be a system-versioned table.