### PR TITLE
MDEV-14632 Assertion `!((new_col->prtype ^ col->prtype) & ~256U)' failed in row_log_table_apply_convert_mrec

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7100,11 +7100,11 @@ bool Vers_parse_info::fix_alter_info(THD *thd, Alter_info *alter_info,
 
   if (with_system_versioning || without_system_versioning)
   {
-    // This is needed to disable Online DDL which is not implemented yet for
-    // ADD/DROP SYSTEM VERSIONING.
+    // Disable Online DDL which is not implemented yet for ADD/DROP SYSTEM VERSIONING.
     if (thd->mdl_context.upgrade_shared_lock(table->mdl_ticket, MDL_EXCLUSIVE,
                                              thd->variables.lock_wait_timeout))
     {
+      my_error(ER_LOCK_WAIT_TIMEOUT, MYF(0));
       return true;
     }
     alter_info->requested_lock= Alter_info::ALTER_TABLE_LOCK_EXCLUSIVE;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7098,6 +7098,18 @@ bool Vers_parse_info::fix_alter_info(THD *thd, Alter_info *alter_info,
   if (!need_check() && !share->versioned)
     return false;
 
+  if (with_system_versioning || without_system_versioning)
+  {
+    // This is needed to disable Online DDL which is not implemented yet for
+    // ADD/DROP SYSTEM VERSIONING.
+    if (thd->mdl_context.upgrade_shared_lock(table->mdl_ticket, MDL_EXCLUSIVE,
+                                             thd->variables.lock_wait_timeout))
+    {
+      return true;
+    }
+    alter_info->requested_lock= Alter_info::ALTER_TABLE_LOCK_EXCLUSIVE;
+  }
+
   if (with_system_versioning && table->versioned())
   {
     my_error(ER_VERS_ALREADY_VERSIONED, MYF(0), table_name);


### PR DESCRIPTION
SQL: add exclusive lock to ADD/DROP SYSTEM VERSIONING clauses

This is needed because Online DDL is not working yet for such queries.