### PR TITLE
MDEV-14632 Assertion `!((new_col->prtype ^ col->prtype) & ~256U)' failed in row_log_table_apply_convert_mrec

### DIFF
--- a/mysql-test/suite/versioning/r/online.result
+++ b/mysql-test/suite/versioning/r/online.result
@@ -1,32 +1,38 @@
 set system_versioning_alter_history=keep;
-create or replace table t (a int) engine=innodb;
+create or replace table t (a int, b int) engine=innodb;
 alter table t add system versioning, lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
-alter table t add system versioning;
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
+alter table t add system versioning, lock=shared;
+alter table t drop column b, lock=none;
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
+alter table t drop column b, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned tables. Try ALGORITHM=COPY
 alter table t add index idx(a), lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
 alter table t drop system versioning, lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
+alter table t drop system versioning, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned tables. Try ALGORITHM=COPY
 set global system_versioning_transaction_registry=on;
 Warnings:
 Warning	4144	Transaction-based system versioning is EXPERIMENTAL and is subject to change in future.
-create or replace table t (a int) engine=innodb;
+create or replace table t (a int, b int) engine=innodb;
 alter table t
 add s bigint unsigned as row start,
 add e bigint unsigned as row end,
 add period for system_time(s, e),
 add system versioning,
 lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
 alter table t
 add s bigint unsigned as row start,
 add e bigint unsigned as row end,
 add period for system_time(s, e),
 add system versioning;
+alter table t drop column b, lock=none;
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
 alter table t add index idx(a), lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
 alter table t drop column s, drop column e;
 alter table t drop system versioning, lock=none;
-ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED
+ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned tables. Try LOCK=SHARED
 set global system_versioning_transaction_registry=off;
 drop table t;

--- a/mysql-test/suite/versioning/t/online.test
+++ b/mysql-test/suite/versioning/t/online.test
@@ -2,21 +2,26 @@
 
 set system_versioning_alter_history=keep;
 
-create or replace table t (a int) engine=innodb;
+create or replace table t (a int, b int) engine=innodb;
 
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 alter table t add system versioning, lock=none;
-alter table t add system versioning;
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+alter table t add system versioning, lock=shared;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t drop column b, lock=none;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t drop column b, algorithm=inplace;
 alter table t add index idx(a), lock=none;
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 alter table t drop system versioning, lock=none;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t drop system versioning, algorithm=inplace;
 
 
 set global system_versioning_transaction_registry=on;
-create or replace table t (a int) engine=innodb;
+create or replace table t (a int, b int) engine=innodb;
 
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 alter table t
   add s bigint unsigned as row start,
   add e bigint unsigned as row end,
@@ -28,10 +33,11 @@ alter table t
   add e bigint unsigned as row end,
   add period for system_time(s, e),
   add system versioning;
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t drop column b, lock=none;
 alter table t add index idx(a), lock=none;
 alter table t drop column s, drop column e;
---error ER_ALTER_OPERATION_NOT_SUPPORTED
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 alter table t drop system versioning, lock=none;
 
 set global system_versioning_transaction_registry=off;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7935,3 +7935,6 @@ ER_VERS_TRUNCATE_VIEW
 
 ER_VERS_TEMPORARY
 	eng "%s prohibited for TEMPORARY tables"
+
+ER_VERS_ONLINE_NOT_IMPLEMENTED
+        eng "Not implemented for system-versioned tables"

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -696,8 +696,10 @@ ha_innobase::check_if_supported_inplace_alter(
 {
 	DBUG_ENTER("check_if_supported_inplace_alter");
 
-	if (altered_table->versioned(VERS_TIMESTAMP)
-	    || ha_alter_info->handler_flags & Alter_inplace_info::ALTER_DROP_SYSTEM_VERSIONING) {
+	if ((table->versioned(VERS_TIMESTAMP) || altered_table->versioned(VERS_TIMESTAMP))
+	    && ha_alter_info->handler_flags & INNOBASE_ALTER_REBUILD) {
+		ha_alter_info->unsupported_reason =
+			innobase_get_err_msg(ER_VERS_ONLINE_NOT_IMPLEMENTED);
 		DBUG_RETURN(HA_ALTER_INPLACE_NOT_SUPPORTED);
 	}
 
@@ -1230,9 +1232,10 @@ next_column:
 	}
 
 	// FIXME: implement Online DDL for system-versioned tables
-	DBUG_ASSERT(!altered_table->versioned(VERS_TIMESTAMP));
-	if (altered_table->versioned(VERS_TRX_ID)
-	    || ha_alter_info->handler_flags & Alter_inplace_info::ALTER_DROP_SYSTEM_VERSIONING) {
+	if ((table->versioned(VERS_TRX_ID) || altered_table->versioned(VERS_TRX_ID))
+	    && ha_alter_info->handler_flags & INNOBASE_ALTER_REBUILD) {
+		ha_alter_info->unsupported_reason =
+			innobase_get_err_msg(ER_VERS_ONLINE_NOT_IMPLEMENTED);
 		online = false;
 	}
 


### PR DESCRIPTION
ha_innobase::check_if_supported_inplace_alter(): enabled non-rebuilding operations for trx_id-based system-versioning tables

Also added better error message for not implemented operations.