### PR TITLE
MDEV-14744 Assertion `table->versioned() == m_prebuilt->table->versioned()' failed in ha_innobase::open

### DIFF
--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -432,5 +432,16 @@ alter table t change column if exists b c bigint unsigned generated always as ro
 ERROR HY000: This is not yet supported for generated columns
 alter table t change column if exists b c bigint unsigned generated always as row end;
 ERROR HY000: This is not yet supported for generated columns
+drop table t;
+# MDEV-14744 trx_id-based and transaction-based mixup in assertion
+create or replace table t (c text) engine=innodb with system versioning;
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+alter table t add fulltext key (c);
+Warnings:
+Warning	124	InnoDB rebuilding table to add column FTS_DOC_ID
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/r/foreign.result
+++ b/mysql-test/suite/versioning/r/foreign.result
@@ -1,6 +1,3 @@
-set global system_versioning_transaction_registry=on;
-Warnings:
-Warning	4143	Transaction-based system versioning is EXPERIMENTAL and is subject to change in future.
 #################
 # Test RESTRICT #
 #################
@@ -9,9 +6,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e),
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end),
 foreign key(parent_id) references parent(id)
 on delete restrict
 on update restrict
@@ -42,9 +39,9 @@ id int(10) unsigned unique key
 ) engine innodb;
 create table child(
 parent_id int(10) unsigned primary key,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e),
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end),
 foreign key(parent_id) references parent(id)
 ) engine innodb with system versioning;
 insert into parent values(1);
@@ -61,9 +58,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e),
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end),
 foreign key(parent_id) references parent(id)
 on delete cascade
 on update cascade
@@ -96,9 +93,9 @@ drop table child;
 drop table parent;
 create or replace table parent (
 id int primary key,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e)
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end)
 ) with system versioning
 engine innodb;
 create or replace table child (
@@ -124,9 +121,6 @@ engine innodb;
 create or replace table child (
 id int primary key,
 parent_id int not null,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e),
 constraint `parent-fk`
   foreign key (parent_id) references parent (id)
 on delete cascade
@@ -154,9 +148,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e),
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end),
 foreign key(parent_id) references parent(id)
 on delete set null
 on update set null
@@ -185,9 +179,9 @@ drop table parent;
 ###########################
 create or replace table parent(
 id int unique key,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e)
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end)
 ) engine innodb with system versioning;
 create or replace table child(
 parent_id int,
@@ -217,17 +211,17 @@ drop table parent;
 create or replace table a (
 cola int(10) primary key,
 v_cola int(10) as (cola mod 10) virtual,
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e)
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end)
 ) engine=innodb with system versioning;
 create index v_cola on a (v_cola);
 create or replace table b(
 cola int(10),
 v_cola int(10),
-s bigint unsigned as row start invisible,
-e bigint unsigned as row end invisible,
-period for system_time(s, e)
+sys_start SYS_DATATYPE as row start invisible,
+sys_end SYS_DATATYPE as row end invisible,
+period for system_time(sys_start, sys_end)
 ) engine=innodb with system versioning;
 alter table b add constraint `v_cola_fk`
 foreign key (v_cola) references a (v_cola);
@@ -236,4 +230,3 @@ insert into b(cola, v_cola) values (10,2);
 delete from a;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`b`, CONSTRAINT `v_cola_fk` FOREIGN KEY (`v_cola`) REFERENCES `a` (`v_cola`))
 drop table b, a;
-set global system_versioning_transaction_registry=off;

--- a/mysql-test/suite/versioning/r/foreign.result
+++ b/mysql-test/suite/versioning/r/foreign.result
@@ -1,3 +1,6 @@
+set global system_versioning_transaction_registry=on;
+Warnings:
+Warning	4143	Transaction-based system versioning is EXPERIMENTAL and is subject to change in future.
 #################
 # Test RESTRICT #
 #################
@@ -6,6 +9,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e),
 foreign key(parent_id) references parent(id)
 on delete restrict
 on update restrict
@@ -36,6 +42,9 @@ id int(10) unsigned unique key
 ) engine innodb;
 create table child(
 parent_id int(10) unsigned primary key,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e),
 foreign key(parent_id) references parent(id)
 ) engine innodb with system versioning;
 insert into parent values(1);
@@ -52,6 +61,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e),
 foreign key(parent_id) references parent(id)
 on delete cascade
 on update cascade
@@ -83,7 +95,10 @@ parent_id
 drop table child;
 drop table parent;
 create or replace table parent (
-id int primary key
+id int primary key,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e)
 ) with system versioning
 engine innodb;
 create or replace table child (
@@ -109,6 +124,9 @@ engine innodb;
 create or replace table child (
 id int primary key,
 parent_id int not null,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e),
 constraint `parent-fk`
   foreign key (parent_id) references parent (id)
 on delete cascade
@@ -136,6 +154,9 @@ id int unique key
 ) engine innodb;
 create table child(
 parent_id int,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e),
 foreign key(parent_id) references parent(id)
 on delete set null
 on update set null
@@ -163,7 +184,10 @@ drop table parent;
 # Parent table is foreign #
 ###########################
 create or replace table parent(
-id int unique key
+id int unique key,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e)
 ) engine innodb with system versioning;
 create or replace table child(
 parent_id int,
@@ -192,12 +216,18 @@ drop table parent;
 ###################
 create or replace table a (
 cola int(10) primary key,
-v_cola int(10) as (cola mod 10) virtual
+v_cola int(10) as (cola mod 10) virtual,
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e)
 ) engine=innodb with system versioning;
 create index v_cola on a (v_cola);
 create or replace table b(
 cola int(10),
-v_cola int(10)
+v_cola int(10),
+s bigint unsigned as row start invisible,
+e bigint unsigned as row end invisible,
+period for system_time(s, e)
 ) engine=innodb with system versioning;
 alter table b add constraint `v_cola_fk`
 foreign key (v_cola) references a (v_cola);
@@ -206,3 +236,4 @@ insert into b(cola, v_cola) values (10,2);
 delete from a;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`b`, CONSTRAINT `v_cola_fk` FOREIGN KEY (`v_cola`) REFERENCES `a` (`v_cola`))
 drop table b, a;
+set global system_versioning_transaction_registry=off;

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -368,6 +368,12 @@ create or replace temporary table t (a int);
 alter table t change column if exists b c bigint unsigned generated always as row start;
 --error ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
 alter table t change column if exists b c bigint unsigned generated always as row end;
+drop table t;
+
+--echo # MDEV-14744 trx_id-based and transaction-based mixup in assertion
+create or replace table t (c text) engine=innodb with system versioning;
+show create table t;
+alter table t add fulltext key (c);
 
 
 drop database test;

--- a/mysql-test/suite/versioning/t/foreign.combinations
+++ b/mysql-test/suite/versioning/t/foreign.combinations
@@ -1,0 +1,5 @@
+[timestamp]
+default-storage-engine=innodb
+
+[trx_id]
+default-storage-engine=innodb

--- a/mysql-test/suite/versioning/t/foreign.test
+++ b/mysql-test/suite/versioning/t/foreign.test
@@ -1,20 +1,19 @@
--- source include/have_innodb.inc
-
-set global system_versioning_transaction_registry=on;
+--source suite/versioning/common.inc
 
 --echo #################
 --echo # Test RESTRICT #
 --echo #################
 
-create table parent(
+eval create table parent(
   id int unique key
 ) engine innodb;
 
-create table child(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create table child(
   parent_id int,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e),
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end),
   foreign key(parent_id) references parent(id)
     on delete restrict
     on update restrict
@@ -43,15 +42,16 @@ drop table parent;
 --echo # Test when clustered index is a foreign key #
 --echo ##############################################
 
-create table parent(
+eval create table parent(
   id int(10) unsigned unique key
 ) engine innodb;
 
-create table child(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create table child(
   parent_id int(10) unsigned primary key,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e),
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end),
   foreign key(parent_id) references parent(id)
 ) engine innodb with system versioning;
 
@@ -68,15 +68,16 @@ drop table parent;
 --echo # Test CASCADE #
 --echo ################
 
-create table parent(
+eval create table parent(
   id int unique key
 ) engine innodb;
 
-create table child(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create table child(
   parent_id int,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e),
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end),
   foreign key(parent_id) references parent(id)
     on delete cascade
     on update cascade
@@ -104,15 +105,16 @@ select * from child for system_time all;
 drop table child;
 drop table parent;
 
-create or replace table parent (
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table parent (
   id int primary key,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e)
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end)
 ) with system versioning
 engine innodb;
 
-create or replace table child (
+eval create or replace table child (
   x int,
   parent_id int not null,
   constraint `parent-fk`
@@ -130,17 +132,14 @@ select * from child;
 drop table child;
 drop table parent;
 
-create or replace table parent (
+eval create or replace table parent (
   id int primary key
 )
 engine innodb;
 
-create or replace table child (
+eval create or replace table child (
   id int primary key,
   parent_id int not null,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e),
   constraint `parent-fk`
   foreign key (parent_id) references parent (id)
       on delete cascade
@@ -164,15 +163,16 @@ drop table parent;
 --echo # Test SET NULL #
 --echo #################
 
-create table parent(
+eval create table parent(
   id int unique key
 ) engine innodb;
 
-create table child(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create table child(
   parent_id int,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e),
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end),
   foreign key(parent_id) references parent(id)
     on delete set null
     on update set null
@@ -209,14 +209,15 @@ drop table parent;
 --echo # Parent table is foreign #
 --echo ###########################
 
-create or replace table parent(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table parent(
   id int unique key,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e)
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end)
 ) engine innodb with system versioning;
 
-create or replace table child(
+eval create or replace table child(
   parent_id int,
   foreign key(parent_id) references parent(id)
 ) engine innodb;
@@ -248,22 +249,24 @@ drop table parent;
 --echo # crash on DELETE #
 --echo ###################
 
-create or replace table a (
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table a (
   cola int(10) primary key,
   v_cola int(10) as (cola mod 10) virtual,
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e)
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end)
 ) engine=innodb with system versioning;
 
-create index v_cola on a (v_cola);
+eval create index v_cola on a (v_cola);
 
-create or replace table b(
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table b(
   cola int(10),
   v_cola int(10),
-  s bigint unsigned as row start invisible,
-  e bigint unsigned as row end invisible,
-  period for system_time(s, e)
+  sys_start $sys_datatype_expl as row start invisible,
+  sys_end $sys_datatype_expl as row end invisible,
+  period for system_time(sys_start, sys_end)
 ) engine=innodb with system versioning;
 
 alter table b add constraint `v_cola_fk`
@@ -275,4 +278,5 @@ insert into b(cola, v_cola) values (10,2);
 delete from a;
 
 drop table b, a;
-set global system_versioning_transaction_registry=off;
+
+--source suite/versioning/common_finish.inc

--- a/mysql-test/suite/versioning/t/foreign.test
+++ b/mysql-test/suite/versioning/t/foreign.test
@@ -1,5 +1,7 @@
 -- source include/have_innodb.inc
 
+set global system_versioning_transaction_registry=on;
+
 --echo #################
 --echo # Test RESTRICT #
 --echo #################
@@ -10,6 +12,9 @@ create table parent(
 
 create table child(
   parent_id int,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e),
   foreign key(parent_id) references parent(id)
     on delete restrict
     on update restrict
@@ -44,6 +49,9 @@ create table parent(
 
 create table child(
   parent_id int(10) unsigned primary key,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e),
   foreign key(parent_id) references parent(id)
 ) engine innodb with system versioning;
 
@@ -66,6 +74,9 @@ create table parent(
 
 create table child(
   parent_id int,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e),
   foreign key(parent_id) references parent(id)
     on delete cascade
     on update cascade
@@ -94,7 +105,10 @@ drop table child;
 drop table parent;
 
 create or replace table parent (
-  id int primary key
+  id int primary key,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e)
 ) with system versioning
 engine innodb;
 
@@ -124,6 +138,9 @@ engine innodb;
 create or replace table child (
   id int primary key,
   parent_id int not null,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e),
   constraint `parent-fk`
   foreign key (parent_id) references parent (id)
       on delete cascade
@@ -153,6 +170,9 @@ create table parent(
 
 create table child(
   parent_id int,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e),
   foreign key(parent_id) references parent(id)
     on delete set null
     on update set null
@@ -190,7 +210,10 @@ drop table parent;
 --echo ###########################
 
 create or replace table parent(
-  id int unique key
+  id int unique key,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e)
 ) engine innodb with system versioning;
 
 create or replace table child(
@@ -227,14 +250,20 @@ drop table parent;
 
 create or replace table a (
   cola int(10) primary key,
-  v_cola int(10) as (cola mod 10) virtual
+  v_cola int(10) as (cola mod 10) virtual,
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e)
 ) engine=innodb with system versioning;
 
 create index v_cola on a (v_cola);
 
 create or replace table b(
   cola int(10),
-  v_cola int(10)
+  v_cola int(10),
+  s bigint unsigned as row start invisible,
+  e bigint unsigned as row end invisible,
+  period for system_time(s, e)
 ) engine=innodb with system versioning;
 
 alter table b add constraint `v_cola_fk`
@@ -246,3 +275,4 @@ insert into b(cola, v_cola) values (10,2);
 delete from a;
 
 drop table b, a;
+set global system_versioning_transaction_registry=off;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3584,6 +3584,8 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
     */
     if (sql_field->stored_in_db())
       record_offset+= sql_field->pack_length;
+    if (sql_field->flags & VERS_SYSTEM_FIELD)
+      continue;
     if (sql_field->invisible == INVISIBLE_USER &&
         sql_field->flags & NOT_NULL_FLAG &&
         sql_field->flags & NO_DEFAULT_VALUE_FLAG)

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6556,10 +6556,6 @@ no_such_table:
 		}
 	}
 
-	if (table && m_prebuilt->table) {
-		ut_ad(table->versioned(VERS_TRX_ID) == m_prebuilt->table->versioned());
-	}
-
 	info(HA_STATUS_NO_LOCK | HA_STATUS_VARIABLE | HA_STATUS_CONST | HA_STATUS_OPEN);
 	DBUG_RETURN(0);
 }
@@ -11418,7 +11414,7 @@ create_table_info_t::create_table_def()
 		Field*	field = m_form->field[i];
 		ulint vers_row = 0;
 
-		if (m_form->versioned(VERS_TRX_ID)) {
+		if (m_form->versioned()) {
 			if (i == m_form->s->row_start_field) {
 				vers_row = DATA_VERS_START;
 			} else if (i == m_form->s->row_end_field) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6557,7 +6557,7 @@ no_such_table:
 	}
 
 	if (table && m_prebuilt->table) {
-		ut_ad(table->versioned() == m_prebuilt->table->versioned());
+		ut_ad(table->versioned(VERS_TRX_ID) == m_prebuilt->table->versioned());
 	}
 
 	info(HA_STATUS_NO_LOCK | HA_STATUS_VARIABLE | HA_STATUS_CONST | HA_STATUS_OPEN);
@@ -11418,7 +11418,7 @@ create_table_info_t::create_table_def()
 		Field*	field = m_form->field[i];
 		ulint vers_row = 0;
 
-		if (m_form->versioned()) {
+		if (m_form->versioned(VERS_TRX_ID)) {
 			if (i == m_form->s->row_start_field) {
 				vers_row = DATA_VERS_START;
 			} else if (i == m_form->s->row_end_field) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6556,6 +6556,10 @@ no_such_table:
 		}
 	}
 
+	if (table && m_prebuilt->table) {
+		ut_ad(table->versioned() == m_prebuilt->table->versioned());
+	}
+
 	info(HA_STATUS_NO_LOCK | HA_STATUS_VARIABLE | HA_STATUS_CONST | HA_STATUS_OPEN);
 	DBUG_RETURN(0);
 }

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4995,7 +4995,7 @@ new_clustered_failed:
 				field_type |= DATA_UNSIGNED;
 			}
 
-			if (altered_table->versioned(VERS_TRX_ID)) {
+			if (altered_table->versioned()) {
 				if (i == altered_table->s->row_start_field) {
 					field_type |= DATA_VERS_START;
 				} else if (i ==


### PR DESCRIPTION
IB: do not mix trx_id and timestamp versioning

SQL: also fixes sys_trx fields in queries like `create index idx on t (a)`
