### PR TITLE
MDEV-14871 Server crashes in fill_record / fill_record_n_invoke_before_triggers upon inserting into versioned table with trigger

### DIFF
--- a/mysql-test/suite/versioning/r/insert.result
+++ b/mysql-test/suite/versioning/r/insert.result
@@ -358,4 +358,7 @@ a
 select * from t1 for system_time as of sysdate(6);
 a
 1
+create or replace table t1 (pk int primary key) with system versioning;
+create trigger tr before insert on t1 for each row select 1 into @a;
+insert into t1 values (1),(2);
 drop table t1;

--- a/mysql-test/suite/versioning/r/insert.result
+++ b/mysql-test/suite/versioning/r/insert.result
@@ -358,6 +358,9 @@ a
 select * from t1 for system_time as of sysdate(6);
 a
 1
+#
+# MDEV-14871 Server crashes in fill_record / fill_record_n_invoke_before_triggers upon inserting into versioned table with trigger
+#
 create or replace table t1 (pk int primary key) with system versioning;
 create trigger tr before insert on t1 for each row select 1 into @a;
 insert into t1 values (1),(2);

--- a/mysql-test/suite/versioning/t/insert.test
+++ b/mysql-test/suite/versioning/t/insert.test
@@ -252,9 +252,9 @@ insert t1 values (1);
 select * from t1 for system_time as of now(6);
 select * from t1 for system_time as of sysdate(6);
 
-#
-# MDEV-14871 Server crashes in fill_record / fill_record_n_invoke_before_triggers upon inserting into versioned table with trigger
-#
+--echo #
+--echo # MDEV-14871 Server crashes in fill_record / fill_record_n_invoke_before_triggers upon inserting into versioned table with trigger
+--echo #
 create or replace table t1 (pk int primary key) with system versioning;
 create trigger tr before insert on t1 for each row select 1 into @a;
 insert into t1 values (1),(2);

--- a/mysql-test/suite/versioning/t/insert.test
+++ b/mysql-test/suite/versioning/t/insert.test
@@ -251,4 +251,12 @@ create table t1 (a int) with system versioning;
 insert t1 values (1);
 select * from t1 for system_time as of now(6);
 select * from t1 for system_time as of sysdate(6);
+
+#
+# MDEV-14871 Server crashes in fill_record / fill_record_n_invoke_before_triggers upon inserting into versioned table with trigger
+#
+create or replace table t1 (pk int primary key) with system versioning;
+create trigger tr before insert on t1 for each row select 1 into @a;
+insert into t1 values (1),(2);
+
 drop table t1;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -2240,6 +2240,7 @@ Field *Field::make_new_field(MEM_ROOT *root, TABLE *new_table,
                 VERS_SYS_START_FLAG | VERS_SYS_END_FLAG |
                 VERS_UPDATE_UNVERSIONED_FLAG);
   tmp->reset_fields();
+  tmp->invisible= VISIBLE;
   return tmp;
 }
 

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -2240,7 +2240,6 @@ Field *Field::make_new_field(MEM_ROOT *root, TABLE *new_table,
                 VERS_SYS_START_FLAG | VERS_SYS_END_FLAG |
                 VERS_UPDATE_UNVERSIONED_FLAG);
   tmp->reset_fields();
-  tmp->invisible= VISIBLE;
   return tmp;
 }
 

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -1228,7 +1228,7 @@ bool Table_triggers_list::prepare_record_accessors(TABLE *table)
     uchar null_bit= 1;
     for (fld= table->field, trg_fld= record0_field; *fld; fld++, trg_fld++)
     {
-      if (!(*fld)->null_ptr && !(*fld)->vcol_info)
+      if (!(*fld)->null_ptr && !(*fld)->vcol_info && !(*fld)->vers_sys_field())
       {
         Field *f;
         if (!(f= *trg_fld= (*fld)->make_new_field(&table->mem_root, table,


### PR DESCRIPTION
```c++
#0  Field::make_new_field (this=0x7fffdc006c30, root=0x7fffdc18eea0, new_table=0x7fffdc18e3e0, keep_type=true) at field.cc:2243
#1  Table_triggers_list::prepare_record_accessors (this=0x7fffdc1226c8, table=0x7fffdc18e3e0) at sql_trigger.cc:1234
#2  Table_triggers_list::check_n_load (thd=0x7fffdc000d50, db=0x7fffdc0aae38 "test", table_name=0x7fffdc0aae3d "t1", table=0x7fffdc18e3e0, names_only=false) at sql_trigger.cc:1593
#3  open_table_entry_fini (thd=0x7fffdc000d50, share=0x7fffdc0aa7c8, entry=0x7fffdc18e3e0) at sql_base.cc:2682
#4  open_table (thd=0x7fffdc000d50, table_list=0x7fffdc015030, ot_ctx=0x7fffeebc5ba8) at sql_base.cc:1926
#5  open_and_process_table (thd=0x7fffdc000d50, lex=0x7fffdc004a20, tables=0x7fffdc015030, counter=0x7fffeebc5cac, flags=0, prelocking_strategy=0x7fffeebc5d20, has_prelocking_list=false, ot_ctx=0x7fffeebc5ba8) at sql_base.cc:3467
#6  open_tables (thd=0x7fffdc000d50, options=..., start=0x7fffeebc5cc0, counter=0x7fffeebc5cac, flags=0, prelocking_strategy=0x7fffeebc5d20) at sql_base.cc:3985
#7  open_and_lock_tables (thd=0x7fffdc000d50, options=..., tables=0x7fffdc015030, derived=true, flags=0, prelocking_strategy=0x7fffeebc5d20) at sql_base.cc:4742
#8  open_and_lock_tables (thd=0x7fffdc000d50, tables=0x7fffdc015030, derived=true, flags=0) at sql_base.h:494
#9  mysql_insert (thd=0x7fffdc000d50, table_list=0x7fffdc015030, fields=List<Item> with 0 elements, values_list=..., update_fields=List<Item> with 0 elements, update_values=List<Item> with 0 elements, duplic=DUP_ERROR, ignore=false) at sql_insert.cc:766
#10 mysql_execute_command (thd=0x7fffdc000d50) at sql_parse.cc:4704
#11 mysql_parse (thd=0x7fffdc000d50, rawbuf=0x7fffdc014f48 "insert into t1 values (1),(2)", length=29, parser_state=0x7fffeebc9410, is_com_multi=false, is_next_command=false) at sql_parse.cc:7991
```