### PR TITLE
MDEV-14932 AddressSanitizer: heap-use-after-free in maria_status or Transaction not registered for MariaDB 2PC, but transaction is active

### DIFF
--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -416,10 +416,10 @@ ERROR HY000: Duplicate partition name p1
 insert into t1 values (1);
 unlock tables;
 # MDEV-14932 Transaction not registered for MariaDB 2PC, but transaction is active
-create or replace table t1 (i int) engine=innodb with system versioning
+create or replace table t1 (i int) with system versioning
 partition by system_time interval 1 month (partition p1 history,
 partition pn current);
-create or replace table t2 engine=innodb select * from information_schema.tables;
+create or replace table t2 select * from information_schema.tables;
 insert into t2 select * from information_schema.tables;
 # Test cleanup
 drop database test;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -415,6 +415,12 @@ alter table t1 add partition (partition p1 history);
 ERROR HY000: Duplicate partition name p1
 insert into t1 values (1);
 unlock tables;
+# MDEV-14932 Transaction not registered for MariaDB 2PC, but transaction is active
+create or replace table t1 (i int) engine=innodb with system versioning
+partition by system_time interval 1 month (partition p1 history,
+partition pn current);
+create or replace table t2 engine=innodb select * from information_schema.tables;
+insert into t2 select * from information_schema.tables;
 # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -360,6 +360,14 @@ alter table t1 add partition (partition p1 history);
 insert into t1 values (1);
 unlock tables;
 
+--echo # MDEV-14932 Transaction not registered for MariaDB 2PC, but transaction is active
+create or replace table t1 (i int) engine=innodb with system versioning
+  partition by system_time interval 1 month (partition p1 history,
+                                             partition pn current);
+create or replace table t2 engine=innodb select * from information_schema.tables;
+insert into t2 select * from information_schema.tables;
+
+
 --echo # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -361,10 +361,10 @@ insert into t1 values (1);
 unlock tables;
 
 --echo # MDEV-14932 Transaction not registered for MariaDB 2PC, but transaction is active
-create or replace table t1 (i int) engine=innodb with system versioning
+create or replace table t1 (i int) with system versioning
   partition by system_time interval 1 month (partition p1 history,
                                              partition pn current);
-create or replace table t2 engine=innodb select * from information_schema.tables;
+create or replace table t2 select * from information_schema.tables;
 insert into t2 select * from information_schema.tables;
 
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -3122,6 +3122,7 @@ enum open_frm_error open_table_from_share(THD *thd, TABLE_SHARE *share,
   uchar *record, *bitmaps;
   Field **field_ptr;
   uint8 save_context_analysis_only= thd->lex->context_analysis_only;
+  bool only_view_structure= thd->lex->sql_command == SQLCOM_SHOW_FIELDS;
   DBUG_ENTER("open_table_from_share");
   DBUG_PRINT("enter",("name: '%s.%s'  form: %p", share->db.str,
                       share->table_name.str, outparam));
@@ -3506,7 +3507,8 @@ partititon_err:
 
 #ifdef WITH_PARTITION_STORAGE_ENGINE
   if (outparam->part_info &&
-    outparam->part_info->part_type == VERSIONING_PARTITION)
+      outparam->part_info->part_type == VERSIONING_PARTITION &&
+      !only_view_structure)
   {
     Query_arena *backup_stmt_arena_ptr= thd->stmt_arena;
     Query_arena backup_arena;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -3122,7 +3122,6 @@ enum open_frm_error open_table_from_share(THD *thd, TABLE_SHARE *share,
   uchar *record, *bitmaps;
   Field **field_ptr;
   uint8 save_context_analysis_only= thd->lex->context_analysis_only;
-  bool only_view_structure= thd->lex->sql_command == SQLCOM_SHOW_FIELDS;
   DBUG_ENTER("open_table_from_share");
   DBUG_PRINT("enter",("name: '%s.%s'  form: %p", share->db.str,
                       share->table_name.str, outparam));
@@ -3508,7 +3507,7 @@ partititon_err:
 #ifdef WITH_PARTITION_STORAGE_ENGINE
   if (outparam->part_info &&
       outparam->part_info->part_type == VERSIONING_PARTITION &&
-      !only_view_structure)
+      thd->lex->sql_command != SQLCOM_SHOW_FIELDS)
   {
     Query_arena *backup_stmt_arena_ptr= thd->stmt_arena;
     Query_arena backup_arena;


### PR DESCRIPTION
Do not update min/max stats for versioned partitined tables when only need
to see it structure.

Details are [here](https://jira.mariadb.org/browse/MDEV-14932)