### PR TITLE
MDEV-15056 Partition pruning doesn't prune in system-versioned table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# System versioning implementation for MariaDB
+
 ## MariaDB: drop-in replacement for MySQL
 
 MariaDB is designed as a drop-in replacement of MySQL(R) with more

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -143,6 +143,18 @@ N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N
 explain partitions select * from tN for system_time as of current_timestamp;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
 N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of (current_timestamp);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now();
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now(N);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now(N);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
 set @str= concat('select row_start from t1 partition (pn) into @ts0');
 prepare stmt from @str;
 execute stmt;
@@ -424,6 +436,31 @@ partition by system_time interval 1 month (partition p1 history,
 partition pn current);
 create or replace table t2 select * from information_schema.tables;
 insert into t2 select * from information_schema.tables;
+## pruning subpartitions check
+create or replace table t1 (x int)
+with system versioning
+partition by system_time limit 2
+subpartition by key (x)
+subpartitions 2 (partition p0 history, partition pn current);
+insert into t1 values (1);
+explain partitions select * from tN;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of current_timestamp;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of (current_timestamp);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now();
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now(N);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of now(N);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn_pnspN,pn_pnspN	system	NULL	NULL	NULL	NULL	N	
 # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -139,7 +139,10 @@ x	C	D
 ## pruning check
 explain partitions select * from tN;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-N	SIMPLE	tN	pN,pn	system	NULL	NULL	NULL	NULL	N	
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
+explain partitions select * from tN for system_time as of current_timestamp;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
+N	SIMPLE	tN	pn	system	NULL	NULL	NULL	NULL	N	
 set @str= concat('select row_start from t1 partition (pn) into @ts0');
 prepare stmt from @str;
 execute stmt;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -144,6 +144,14 @@ execute select_pn;
 explain partitions select * from t1;
 --replace_regex /\d/N/ /ALL/system/ /Using where//
 explain partitions select * from t1 for system_time as of current_timestamp;
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of (current_timestamp);
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now();
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now(0);
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now(6);
 
 set @str= concat('select row_start from t1 partition (pn) into @ts0');
 prepare stmt from @str; execute stmt; drop prepare stmt;
@@ -376,6 +384,27 @@ create or replace table t1 (i int) with system versioning
                                              partition pn current);
 create or replace table t2 select * from information_schema.tables;
 insert into t2 select * from information_schema.tables;
+
+--echo ## pruning subpartitions check
+create or replace table t1 (x int)
+with system versioning
+partition by system_time limit 2
+subpartition by key (x)
+subpartitions 2 (partition p0 history, partition pn current);
+insert into t1 values (1);
+
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1;
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of current_timestamp;
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of (current_timestamp);
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now();
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now(0);
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of now(6);
 
 
 --echo # Test cleanup

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -142,6 +142,8 @@ execute select_pn;
 --echo ## pruning check
 --replace_regex /\d/N/ /ALL/system/ /Using where//
 explain partitions select * from t1;
+--replace_regex /\d/N/ /ALL/system/ /Using where//
+explain partitions select * from t1 for system_time as of current_timestamp;
 
 set @str= concat('select row_start from t1 partition (pn) into @ts0');
 prepare stmt from @str; execute stmt; drop prepare stmt;

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -74,7 +74,8 @@ public:
                   NOW_FUNC, NOW_UTC_FUNC, SYSDATE_FUNC, TRIG_COND_FUNC,
                   SUSERVAR_FUNC, GUSERVAR_FUNC, COLLATE_FUNC,
                   EXTRACT_FUNC, CHAR_TYPECAST_FUNC, FUNC_SP, UDF_FUNC,
-                  NEG_FUNC, GSYSVAR_FUNC, DYNCOL_FUNC, JSON_EXTRACT_FUNC };
+                  NEG_FUNC, GSYSVAR_FUNC, DYNCOL_FUNC, JSON_EXTRACT_FUNC,
+                  DATETIME_TYPECAST_FUNC };
   enum Type type() const { return FUNC_ITEM; }
   virtual enum Functype functype() const   { return UNKNOWN_FUNC; }
   Item_func(THD *thd): Item_func_or_sum(thd)

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -1173,6 +1173,7 @@ public:
     Item_temporal_typecast(thd, a) { decimals= dec_arg; }
   const char *func_name() const { return "cast_as_datetime"; }
   const char *cast_type() const { return "datetime"; }
+  virtual enum Functype functype() const { return DATETIME_TYPECAST_FUNC; }
   const Type_handler *type_handler() const { return &type_handler_datetime2; }
   bool get_date(MYSQL_TIME *ltime, ulonglong fuzzy_date);
   void fix_length_and_dec()

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -3673,6 +3673,9 @@ static void mark_full_partition_used_with_parts(partition_info *part_info,
   uint32 end=   start + part_info->num_subparts; 
   DBUG_ENTER("mark_full_partition_used_with_parts");
 
+  if (as_of_current_timestamp_history_part(part_info, part_id))
+    DBUG_VOID_RETURN;
+
   for (; start != end; start++)
   {
     DBUG_PRINT("info", ("1:Mark subpartition %u as used", start));


### PR DESCRIPTION
as_of_current_timestamp_history_part(): checks whether query has explicit or
implicit FOR SYSTEM_TIME AS OF CURRENT_TIMESTAMP clause and HISTORY partition.

mark_full_partition_used_no_parts(): do not mark HISTORY partitions when only
current system rows requested.