### PR TITLE
MDEV-14829 Assertion `0' failed in Protocol::end_statement upon concurrent UPDATE

### DIFF
--- a/mysql-test/suite/versioning/r/update.result
+++ b/mysql-test/suite/versioning/r/update.result
@@ -620,6 +620,5 @@ create or replace table t1 (a int primary key, b int)
 with system versioning engine myisam;
 insert into t1 (a) values (1);
 replace t1 values (1,2),(1,3),(2,4);
-ERROR 23000: Duplicate entry '1-YYYY-MM-DD hh:mm:ss.uuuuuu' for key 'PRIMARY'
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/update.test
+++ b/mysql-test/suite/versioning/t/update.test
@@ -280,8 +280,7 @@ call verify_vtq;
 create or replace table t1 (a int primary key, b int)
 with system versioning engine myisam;
 insert into t1 (a) values (1);
---replace_regex /'1-[- .\d:]+'/'1-YYYY-MM-DD hh:mm:ss.uuuuuu'/
---error ER_DUP_ENTRY
+
 replace t1 values (1,2),(1,3),(2,4);
 
 drop database test;

--- a/sql/field.h
+++ b/sql/field.h
@@ -1106,6 +1106,13 @@ public:
   { return cmp(a, b); }
   virtual int key_cmp(const uchar *str, uint length)
   { return cmp(ptr,str); }
+
+  bool operator<(const Field &rhs) { return cmp(ptr, rhs.ptr) < 0; }
+  bool operator<=(const Field &rhs) { return cmp(ptr, rhs.ptr) <= 0; }
+  bool operator==(const Field &rhs) { return cmp(ptr, rhs.ptr) == 0; }
+  bool operator!=(const Field &rhs) { return !(*this == rhs); }
+  bool operator>=(const Field &rhs) { return cmp(ptr, rhs.ptr) >= 0; }
+  bool operator>(const Field &rhs) { return cmp(ptr, rhs.ptr) > 0; }
   /*
     Update the value m of the 'min_val' field with the current value v
     of this field if force_update is set to TRUE or if v < m.

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1640,6 +1640,11 @@ int vers_insert_history_row(TABLE *table)
   // Set Sys_end to now()
   table->vers_update_end();
 
+  Field *row_start= table->vers_start_field();
+  Field *row_end= table->vers_end_field();
+  if (row_start->cmp(row_start->ptr, row_end->ptr) != -1)
+    return 0;
+
   return table->file->ha_write_row(table->record[0]);
 }
 

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1642,7 +1642,7 @@ int vers_insert_history_row(TABLE *table)
 
   Field *row_start= table->vers_start_field();
   Field *row_end= table->vers_end_field();
-  if (row_start->cmp(row_start->ptr, row_end->ptr) != -1)
+  if (*row_start >= *row_end)
     return 0;
 
   return table->file->ha_write_row(table->record[0]);

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -923,7 +923,6 @@ update_begin:
         }
         else if (!error)
         {
-
           if (has_vers_fields && table->versioned())
           {
             if (table->versioned(VERS_TIMESTAMP))

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -923,25 +923,25 @@ update_begin:
         }
         else if (!error)
         {
-          updated++;
 
           if (has_vers_fields && table->versioned())
           {
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
-              if ((error = vers_insert_history_row(table)))
-              {
+              error= vers_insert_history_row(table);
+              if (!error)
                 restore_record(table, record[2]);
-                break;
-              }
-              restore_record(table, record[2]);
             }
-            updated_sys_ver++;
+            if (!error)
+              updated_sys_ver++;
           }
         }
-        else if (!ignore ||
-                 table->file->is_fatal_error(error, HA_CHECK_ALL))
+
+        if (!error)
+          updated++;
+
+        if (error && (!ignore || table->file->is_fatal_error(error, HA_CHECK_ALL)))
         {
           /*
             If (ignore && error is ignorable) we don't have to


### PR DESCRIPTION
MDEV-14829 consist of at least 3 independent bugs. This commit fixes 2 of them: proper error handling up to `vers_insert_history_row()` and do not store historical rows with zero or negative lifetime.