### PR TITLE
MDEV-14675 Questionable semantics of INTERVAL values in PARTITION BY system_time: converted into seconds

### DIFF
--- a/include/my_time.h
+++ b/include/my_time.h
@@ -249,6 +249,8 @@ enum interval_type
   INTERVAL_MINUTE_MICROSECOND, INTERVAL_SECOND_MICROSECOND, INTERVAL_LAST
 };
 
+const char *get_interval_name(enum interval_type type);
+
 C_MODE_END
 
 #endif /* _my_time_h_ */

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -602,6 +602,83 @@ delete from t1;
 Warnings:
 Note	4114	Versioned table `test`.`t1`: switching from partition `p2` to `p3`
 delete from t1 where a is not null;
+# MDEV-14675 Questionable semantics of INTERVAL values in PARTITION BY system_time: converted into seconds
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 year (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 YEAR 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 quarter (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 3 MONTH 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 month (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 MONTH 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 week (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 7 DAY 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 day (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 DAY 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 hour (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 HOUR 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 minute (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 MINUTE 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 second (partition p0 history, partition pn current);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+ PARTITION BY SYSTEM_TIME INTERVAL 1 SECOND 
+(PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
+ PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 microsecond (partition p0 history, partition pn current);
+ERROR HY000: Wrong parameters for partitioned `t1`: wrong value for 'INTERVAL'
+create or replace table t1 (i int) with system versioning partition by system_time interval -1 second (partition p0 history, partition pn current);
+ERROR HY000: Wrong parameters for partitioned `t1`: wrong value for 'INTERVAL'
 # Test cleanup
 set global debug_dbug=@old_dbug;
 drop database test;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -679,6 +679,22 @@ create or replace table t1 (i int) with system versioning partition by system_ti
 ERROR HY000: Wrong parameters for partitioned `t1`: wrong value for 'INTERVAL'
 create or replace table t1 (i int) with system versioning partition by system_time interval -1 second (partition p0 history, partition pn current);
 ERROR HY000: Wrong parameters for partitioned `t1`: wrong value for 'INTERVAL'
+create or replace table t1 (i int) with system versioning
+partition by system_time interval 1 year (
+partition p0 history, partition p1 history, partition pn current);
+insert into t1 values (1), (2);
+delete from t1 where i=1;
+set timestamp = unix_timestamp(sysdate(6) + interval 2 year);
+delete from t1 where i=2;
+Warnings:
+Note	4114	Versioned table `test`.`t1`: switching from partition `p0` to `p1`
+set timestamp = 0;
+select * from t1 partition(p0);
+i
+1
+select * from t1 partition(p1);
+i
+2
 # Test cleanup
 set global debug_dbug=@old_dbug;
 drop database test;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -618,7 +618,7 @@ Table	Create Table
 t1	CREATE TABLE `t1` (
   `i` int(11) DEFAULT NULL
 ) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
- PARTITION BY SYSTEM_TIME INTERVAL 3 MONTH 
+ PARTITION BY SYSTEM_TIME INTERVAL 1 QUARTER 
 (PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
  PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
 create or replace table t1 (i int) with system versioning partition by system_time interval 1 month (partition p0 history, partition pn current);
@@ -636,7 +636,7 @@ Table	Create Table
 t1	CREATE TABLE `t1` (
   `i` int(11) DEFAULT NULL
 ) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
- PARTITION BY SYSTEM_TIME INTERVAL 7 DAY 
+ PARTITION BY SYSTEM_TIME INTERVAL 1 WEEK 
 (PARTITION `p0` HISTORY ENGINE = DEFAULT_ENGINE,
  PARTITION `pn` CURRENT ENGINE = DEFAULT_ENGINE)
 create or replace table t1 (i int) with system versioning partition by system_time interval 1 day (partition p0 history, partition pn current);

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -580,6 +580,17 @@ create or replace table t1 (i int) with system versioning partition by system_ti
 --error ER_PART_WRONG_VALUE
 create or replace table t1 (i int) with system versioning partition by system_time interval -1 second (partition p0 history, partition pn current);
 
+create or replace table t1 (i int) with system versioning
+  partition by system_time interval 1 year (
+    partition p0 history, partition p1 history, partition pn current);
+insert into t1 values (1), (2);
+delete from t1 where i=1;
+set timestamp = unix_timestamp(sysdate(6) + interval 2 year);
+delete from t1 where i=2;
+set timestamp = 0;
+
+select * from t1 partition(p0);
+select * from t1 partition(p1);
 
 
 --echo # Test cleanup

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -550,6 +550,38 @@ update t1 set a = 4;
 delete from t1;
 delete from t1 where a is not null;
 
+--echo # MDEV-14675 Questionable semantics of INTERVAL values in PARTITION BY system_time: converted into seconds
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 year (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 quarter (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 month (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 week (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 day (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 hour (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 minute (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 second (partition p0 history, partition pn current);
+--replace_result $default_engine DEFAULT_ENGINE
+show create table t1;
+--error ER_PART_WRONG_VALUE
+create or replace table t1 (i int) with system versioning partition by system_time interval 1 microsecond (partition p0 history, partition pn current);
+--error ER_PART_WRONG_VALUE
+create or replace table t1 (i int) with system versioning partition by system_time interval -1 second (partition p0 history, partition pn current);
+
+
+
 --echo # Test cleanup
 set global debug_dbug=@old_dbug;
 drop database test;

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -2237,19 +2237,24 @@ static const char *interval_names[]=
   "second_microsecond"
 };
 
+const char *get_interval_name(enum interval_type type)
+{
+  return interval_names[static_cast<size_t>(type)];
+}
+
 void Item_date_add_interval::print(String *str, enum_query_type query_type)
 {
   args[0]->print_parenthesised(str, query_type, ADDINTERVAL_PRECEDENCE);
   str->append(date_sub_interval?" - interval ":" + interval ");
   args[1]->print_parenthesised(str, query_type, INTERVAL_PRECEDENCE);
   str->append(' ');
-  str->append(interval_names[int_type]);
+  str->append(get_interval_name(int_type));
 }
 
 void Item_extract::print(String *str, enum_query_type query_type)
 {
   str->append(STRING_WITH_LEN("extract("));
-  str->append(interval_names[int_type]);
+  str->append(get_interval_name(int_type));
   str->append(STRING_WITH_LEN(" from "));
   args[0]->print(str, query_type);
   str->append(')');

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -23,6 +23,7 @@
 #include "mariadb.h"
 #include <my_global.h>
 #include <tztime.h>
+#include "sql_time.h"
 #include "sql_priv.h"
 // Required to get server definitions for mysql/plugin.h right
 #include "sql_plugin.h"
@@ -873,23 +874,11 @@ bool partition_info::vers_init_info(THD * thd)
 
 bool partition_info::vers_set_interval(const INTERVAL & i)
 {
-  if (i.neg || i.second_part)
+  if (i.neg || i.second_part || i.empty())
     return true;
 
   DBUG_ASSERT(vers_info);
-
-  // TODO: INTERVAL conversion to seconds leads to mismatch with calendar intervals (MONTH and YEAR)
-  vers_info->interval= static_cast<my_time_t>(
-    i.second +
-    i.minute * 60 +
-    i.hour * 60 * 60 +
-    i.day * 24 * 60 * 60 +
-    i.month * 30 * 24 * 60 * 60 +
-    i.year * 365 * 30 * 24 * 60 * 60);
-
-  if (vers_info->interval == 0)
-    return true;
-
+  vers_info->interval= i;
   return false;
 }
 
@@ -2202,7 +2191,7 @@ bool partition_info::check_partition_info(THD *thd, handlerton **eng_type,
 
   if (hist_parts > 1)
   {
-    if (unlikely(vers_info->limit == 0 && vers_info->interval == 0))
+    if (unlikely(vers_info->limit == 0 && vers_info->interval.empty()))
     {
       push_warning_printf(thd,
         Sql_condition::WARN_LEVEL_WARN,
@@ -3495,6 +3484,24 @@ bool partition_info::vers_trx_id_to_ts(THD* thd, Field* in_trx_id, Field_timesta
   return false;
 }
 
+bool partition_info::vers_interval_exceed(my_time_t max_time, partition_element *part)
+{
+  DBUG_ASSERT(vers_info);
+  if (vers_info->interval.empty())
+    return false;
+  if (!part)
+  {
+    DBUG_ASSERT(vers_info->initialized());
+    part= vers_hist_part();
+  }
+  my_time_t min_time= vers_pruning_stat(Vers_pruning_stat::ROW_END, part).min_time();
+  MYSQL_TIME max;
+  MYSQL_TIME min;
+  current_thd->variables.time_zone->gmt_sec_to_TIME(&max, max_time);
+  current_thd->variables.time_zone->gmt_sec_to_TIME(&min, min_time);
+  date_add_interval(&min, vers_info->get_interval_type(), vers_info->interval);
+  return my_time_compare(&max, &min) > 0;
+}
 
 void partition_info::print_debug(const char *str, uint *value)
 {

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -874,7 +874,7 @@ bool partition_info::vers_init_info(THD * thd)
 
 bool partition_info::vers_set_interval(const Typed_interval & i)
 {
-  if (i.interval.neg || i.interval.second_part || i.interval.empty())
+  if (i.interval.neg || i.interval.second_part || i.empty())
     return true;
 
   DBUG_ASSERT(vers_info);

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -872,9 +872,9 @@ bool partition_info::vers_init_info(THD * thd)
   return false;
 }
 
-bool partition_info::vers_set_interval(const INTERVAL & i)
+bool partition_info::vers_set_interval(const Typed_interval & i)
 {
-  if (i.neg || i.second_part || i.empty())
+  if (i.interval.neg || i.interval.second_part || i.interval.empty())
     return true;
 
   DBUG_ASSERT(vers_info);
@@ -3499,7 +3499,7 @@ bool partition_info::vers_interval_exceed(my_time_t max_time, partition_element 
   MYSQL_TIME min;
   current_thd->variables.time_zone->gmt_sec_to_TIME(&max, max_time);
   current_thd->variables.time_zone->gmt_sec_to_TIME(&min, min_time);
-  date_add_interval(&min, vers_info->get_interval_type(), vers_info->interval);
+  date_add_interval(&min, vers_info->interval.type, vers_info->interval.interval);
   return my_time_compare(&max, &min) > 0;
 }
 

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -872,14 +872,14 @@ bool partition_info::vers_init_info(THD * thd)
   return false;
 }
 
-bool partition_info::vers_set_interval(const Typed_interval & i)
+bool partition_info::vers_set_interval(interval_type type, const INTERVAL &i)
 {
-  if (i.interval.neg || i.interval.second_part || i.empty())
+  if (i.neg || i.second_part)
     return true;
 
   DBUG_ASSERT(vers_info);
-  vers_info->interval= i;
-  return false;
+  vers_info->interval= Typed_interval(type, i);
+  return vers_info->interval.empty();
 }
 
 bool partition_info::vers_set_limit(ulonglong limit)
@@ -3499,7 +3499,7 @@ bool partition_info::vers_interval_exceed(my_time_t max_time, partition_element 
   MYSQL_TIME min;
   current_thd->variables.time_zone->gmt_sec_to_TIME(&max, max_time);
   current_thd->variables.time_zone->gmt_sec_to_TIME(&min, min_time);
-  date_add_interval(&min, vers_info->interval.type, vers_info->interval.interval);
+  date_add_interval(&min, vers_info->interval.type, vers_info->interval.to_interval());
   return my_time_compare(&max, &min) > 0;
 }
 

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -872,9 +872,9 @@ bool partition_info::vers_init_info(THD * thd)
   return false;
 }
 
-bool partition_info::vers_set_interval(interval_type type, const INTERVAL &i)
+bool partition_info::vers_set_interval(interval_type type, const INTERVAL &interval, ulong i)
 {
-  if (i.neg || i.second_part)
+  if (interval.neg || interval.second_part)
     return true;
 
   DBUG_ASSERT(vers_info);

--- a/sql/partition_info.h
+++ b/sql/partition_info.h
@@ -37,40 +37,8 @@ struct st_ddl_log_memory_entry;
 
 struct Typed_interval
 {
-  Typed_interval() : type(INTERVAL_SECOND) { bzero(&interval, sizeof(interval)); }
-  Typed_interval(interval_type type, const INTERVAL &i) : type(type)
-  {
-    switch (type)
-    {
-    case INTERVAL_YEAR:
-      interval= i.year;
-      break;
-    case INTERVAL_QUARTER:
-      interval= i.month / 3;
-      break;
-    case INTERVAL_MONTH:
-      interval= i.month;
-      break;
-    case INTERVAL_WEEK:
-      interval= i.day / 7;
-      break;
-    case INTERVAL_DAY:
-      interval= i.day;
-      break;
-    case INTERVAL_HOUR:
-      interval= i.hour;
-      break;
-    case INTERVAL_MINUTE:
-      interval= i.minute;
-      break;
-    case INTERVAL_SECOND:
-      interval= i.second;
-      break;
-    default:
-      DBUG_ASSERT(false);
-      break;
-    }
-  }
+  Typed_interval() : type(INTERVAL_SECOND), interval(0) {}
+  Typed_interval(interval_type type, uint interval) : type(type), interval(interval) {}
 
   bool empty() const { return interval == 0; }
 
@@ -476,7 +444,7 @@ public:
   bool has_unique_name(partition_element *element);
 
   bool vers_init_info(THD *thd);
-  bool vers_set_interval(interval_type type, const INTERVAL &i);
+  bool vers_set_interval(interval_type type, const INTERVAL &interval, ulong i);
   bool vers_set_limit(ulonglong limit);
   partition_element* vers_part_rotate(THD *thd);
   bool vers_set_expression(THD *thd, partition_element *el, MYSQL_TIME &t);

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -2336,29 +2336,35 @@ char *generate_partition_syntax(THD *thd, partition_info *part_info,
   {
     Vers_part_info *vers_info= part_info->vers_info;
     DBUG_ASSERT(vers_info);
-    const INTERVAL &interval= vers_info->interval;
+    const Typed_interval &interval= vers_info->interval;
     if (!interval.empty())
     {
       err+= str.append(STRING_WITH_LEN("INTERVAL "));
-      switch (vers_info->get_interval_type())
+      switch (interval.type)
       {
       case INTERVAL_YEAR:
-        err+= str.append_ulonglong(interval.year);
+        err+= str.append_ulonglong(interval.interval.year);
+        break;
+      case INTERVAL_QUARTER:
+        err+= str.append_ulonglong(interval.interval.month / 3);
         break;
       case INTERVAL_MONTH:
-        err+= str.append_ulonglong(interval.month);
+        err+= str.append_ulonglong(interval.interval.month);
+        break;
+      case INTERVAL_WEEK:
+        err+= str.append_ulonglong(interval.interval.day / 7);
         break;
       case INTERVAL_DAY:
-        err+= str.append_ulonglong(interval.day);
+        err+= str.append_ulonglong(interval.interval.day);
         break;
       case INTERVAL_HOUR:
-        err+= str.append_ulonglong(interval.hour);
+        err+= str.append_ulonglong(interval.interval.hour);
         break;
       case INTERVAL_MINUTE:
-        err+= str.append_ulonglong(interval.minute);
+        err+= str.append_ulonglong(interval.interval.minute);
         break;
       case INTERVAL_SECOND:
-        err+= str.append_ulonglong(interval.second);
+        err+= str.append_ulonglong(interval.interval.second);
         break;
       default:
         DBUG_ASSERT(false);
@@ -2366,7 +2372,7 @@ char *generate_partition_syntax(THD *thd, partition_info *part_info,
       }
       err+= str.append(STRING_WITH_LEN(" "));
       size_t it = str.length();
-      err+= str.append(get_interval_name(vers_info->get_interval_type()));
+      err+= str.append(get_interval_name(interval.type));
       size_t end = str.length();
       for (; it != end; ++it)
         str[it]= my_toupper(system_charset_info, str[it]);

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -2336,44 +2336,15 @@ char *generate_partition_syntax(THD *thd, partition_info *part_info,
   {
     Vers_part_info *vers_info= part_info->vers_info;
     DBUG_ASSERT(vers_info);
-    const Typed_interval &interval= vers_info->interval;
+    const Typed_interval interval= vers_info->interval;
     if (!interval.empty())
     {
       err+= str.append(STRING_WITH_LEN("INTERVAL "));
-      switch (interval.type)
-      {
-      case INTERVAL_YEAR:
-        err+= str.append_ulonglong(interval.interval.year);
-        break;
-      case INTERVAL_QUARTER:
-        err+= str.append_ulonglong(interval.interval.month / 3);
-        break;
-      case INTERVAL_MONTH:
-        err+= str.append_ulonglong(interval.interval.month);
-        break;
-      case INTERVAL_WEEK:
-        err+= str.append_ulonglong(interval.interval.day / 7);
-        break;
-      case INTERVAL_DAY:
-        err+= str.append_ulonglong(interval.interval.day);
-        break;
-      case INTERVAL_HOUR:
-        err+= str.append_ulonglong(interval.interval.hour);
-        break;
-      case INTERVAL_MINUTE:
-        err+= str.append_ulonglong(interval.interval.minute);
-        break;
-      case INTERVAL_SECOND:
-        err+= str.append_ulonglong(interval.interval.second);
-        break;
-      default:
-        DBUG_ASSERT(false);
-        break;
-      }
+      err+= str.append_ulonglong(interval.interval);
       err+= str.append(STRING_WITH_LEN(" "));
-      size_t it = str.length();
+      size_t it= str.length();
       err+= str.append(get_interval_name(interval.type));
-      size_t end = str.length();
+      size_t end= str.length();
       for (; it != end; ++it)
         str[it]= my_toupper(system_charset_info, str[it]);
       err+= str.append(STRING_WITH_LEN(" "));

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -2336,11 +2336,41 @@ char *generate_partition_syntax(THD *thd, partition_info *part_info,
   {
     Vers_part_info *vers_info= part_info->vers_info;
     DBUG_ASSERT(vers_info);
-    if (vers_info->interval)
+    const INTERVAL &interval= vers_info->interval;
+    if (!interval.empty())
     {
       err+= str.append(STRING_WITH_LEN("INTERVAL "));
-      err+= str.append_ulonglong(vers_info->interval);
-      err+= str.append(STRING_WITH_LEN(" SECOND "));
+      switch (vers_info->get_interval_type())
+      {
+      case INTERVAL_YEAR:
+        err+= str.append_ulonglong(interval.year);
+        break;
+      case INTERVAL_MONTH:
+        err+= str.append_ulonglong(interval.month);
+        break;
+      case INTERVAL_DAY:
+        err+= str.append_ulonglong(interval.day);
+        break;
+      case INTERVAL_HOUR:
+        err+= str.append_ulonglong(interval.hour);
+        break;
+      case INTERVAL_MINUTE:
+        err+= str.append_ulonglong(interval.minute);
+        break;
+      case INTERVAL_SECOND:
+        err+= str.append_ulonglong(interval.second);
+        break;
+      default:
+        DBUG_ASSERT(false);
+        break;
+      }
+      err+= str.append(STRING_WITH_LEN(" "));
+      size_t it = str.length();
+      err+= str.append(get_interval_name(vers_info->get_interval_type()));
+      size_t end = str.length();
+      for (; it != end; ++it)
+        str[it]= my_toupper(system_charset_info, str[it]);
+      err+= str.append(STRING_WITH_LEN(" "));
     }
     if (vers_info->limit)
     {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5849,7 +5849,8 @@ opt_versioning_interval:
            partition_info *part_info= Lex->part_info;
            DBUG_ASSERT(part_info->part_type == VERSIONING_PARTITION);
            INTERVAL interval;
-           if (get_interval_value($2, $3, &interval) || part_info->vers_set_interval($3, interval))
+           if (get_interval_value($2, $3, &interval) ||
+               part_info->vers_set_interval($3, interval, $2->val_uint()))
            {
              my_error(ER_PART_WRONG_VALUE, MYF(0),
                       Lex->create_last_non_select_table->table_name.str,

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5844,7 +5844,7 @@ opt_part_option:
 
 opt_versioning_interval:
          /* empty */ {}
-       | INTERVAL_SYM expr interval
+       | INTERVAL_SYM expr interval_time_stamp
          {
            partition_info *part_info= Lex->part_info;
            DBUG_ASSERT(part_info->part_type == VERSIONING_PARTITION);

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5849,8 +5849,7 @@ opt_versioning_interval:
            partition_info *part_info= Lex->part_info;
            DBUG_ASSERT(part_info->part_type == VERSIONING_PARTITION);
            INTERVAL interval;
-           if (get_interval_value($2, $3, &interval) ||
-               part_info->vers_set_interval(Typed_interval($3, interval)))
+           if (get_interval_value($2, $3, &interval) || part_info->vers_set_interval($3, interval))
            {
              my_error(ER_PART_WRONG_VALUE, MYF(0),
                       Lex->create_last_non_select_table->table_name.str,

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5850,7 +5850,7 @@ opt_versioning_interval:
            DBUG_ASSERT(part_info->part_type == VERSIONING_PARTITION);
            INTERVAL interval;
            if (get_interval_value($2, $3, &interval) ||
-              part_info->vers_set_interval(interval))
+               part_info->vers_set_interval(Typed_interval($3, interval)))
            {
              my_error(ER_PART_WRONG_VALUE, MYF(0),
                       Lex->create_last_non_select_table->table_name.str,

--- a/sql/structs.h
+++ b/sql/structs.h
@@ -184,13 +184,17 @@ typedef struct st_reginfo {		/* Extra info about reg */
 
 typedef enum enum_mysql_timestamp_type timestamp_type;
 
+struct INTERVAL
+{
+  bool empty() const
+  {
+    return !year && !month && !day && !hour && !minute && !second && !second_part;
+  }
 
-typedef struct {
-  ulong year,month,day,hour;
-  ulonglong minute,second,second_part;
+  ulong year, month, day, hour;
+  ulonglong minute, second, second_part;
   bool neg;
-} INTERVAL;
-
+};
 
 typedef struct st_known_date_time_format {
   const char *format_name;

--- a/sql/structs.h
+++ b/sql/structs.h
@@ -184,17 +184,13 @@ typedef struct st_reginfo {		/* Extra info about reg */
 
 typedef enum enum_mysql_timestamp_type timestamp_type;
 
-struct INTERVAL
-{
-  bool empty() const
-  {
-    return !year && !month && !day && !hour && !minute && !second && !second_part;
-  }
 
-  ulong year, month, day, hour;
-  ulonglong minute, second, second_part;
+typedef struct {
+  ulong year,month,day,hour;
+  ulonglong minute,second,second_part;
   bool neg;
-};
+} INTERVAL;
+
 
 typedef struct st_known_date_time_format {
   const char *format_name;


### PR DESCRIPTION
Use INTERVAL insead of seconds in Vers_part_info::interval.
Implementation converts 1 QUARTER to 3 MONTHs, and 1 WEEK to 7 DAYs.

partiton_info::vers_interval_exceed(): convert timestamp to MYSQL_TIME using
timezones, subtract INTERVAL honouring leap years and different month.

Reduce SYSTEM_TIME invervals to a subset which do not use microseconds.