### PR TITLE
mark unversioned fields in system versioning tables

### DIFF
--- a/storage/innobase/dict/dict0mem.cc
+++ b/storage/innobase/dict/dict0mem.cc
@@ -312,14 +312,15 @@ dict_mem_table_add_col(
 
 	dict_mem_fill_column_struct(col, i, mtype, prtype, len);
 
-	switch (prtype & DATA_VERSIONED) {
-	case DATA_VERS_START:
-		ut_ad(!table->vers_start);
-		table->vers_start = i;
-		break;
-	case DATA_VERS_END:
-		ut_ad(!table->vers_end);
-		table->vers_end = i;
+	if ((prtype & DATA_UNVERSIONED) != DATA_UNVERSIONED) {
+		if (prtype & DATA_VERS_START) {
+			ut_ad(!table->vers_start);
+			table->vers_start = i;
+		}
+		if (prtype & DATA_VERS_END) {
+			ut_ad(!table->vers_end);
+			table->vers_end = i;
+		}
 	}
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -11265,9 +11265,9 @@ create_table_info_t::create_table_def()
 				vers_row = DATA_VERS_START;
 			} else if (i == m_form->s->row_end_field) {
 				vers_row = DATA_VERS_END;
-			} else if (!(field->flags
-				     & VERS_UPDATE_UNVERSIONED_FLAG)) {
-				vers_row = DATA_VERSIONED;
+			} else if (field->flags
+				   & VERS_UPDATE_UNVERSIONED_FLAG) {
+				vers_row = DATA_UNVERSIONED;
 			}
 		}
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -5009,9 +5009,9 @@ new_clustered_failed:
 				} else if (i ==
 					   altered_table->s->row_end_field) {
 					field_type |= DATA_VERS_END;
-				} else if (!(field->flags
-					     & VERS_UPDATE_UNVERSIONED_FLAG)) {
-					field_type |= DATA_VERSIONED;
+				} else if (field->flags
+					   & VERS_UPDATE_UNVERSIONED_FLAG) {
+					field_type |= DATA_UNVERSIONED;
 				}
 			}
 

--- a/storage/innobase/include/data0type.h
+++ b/storage/innobase/include/data0type.h
@@ -192,8 +192,9 @@ be less than 256 */
 /** System Versioning */
 #define DATA_VERS_START	16384U	/* start system field */
 #define DATA_VERS_END	32768U	/* end system field */
+#define DATA_VERS_SYS (DATA_VERS_START|DATA_VERS_END)
 /** system-versioned user data column */
-#define DATA_VERSIONED (DATA_VERS_START|DATA_VERS_END)
+#define DATA_UNVERSIONED (DATA_VERS_START|DATA_VERS_END)
 
 /** Check whether locking is disabled (never). */
 #define dict_table_is_locking_disabled(table) false
@@ -543,18 +544,21 @@ struct dtype_t{
 					in bytes */
 
 	/** @return whether this is system field */
-	bool vers_sys_field() const { return prtype & DATA_VERSIONED; }
+	bool vers_sys_field() const
+	{
+		return vers_sys_start() || vers_sys_end();
+	}
 	/** @return whether this is system versioned user field */
-	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
+	bool is_versioned() const { return (prtype & DATA_UNVERSIONED) == 0; }
 	/** @return whether this is the system field start */
 	bool vers_sys_start() const
 	{
-		return (prtype & DATA_VERSIONED) == DATA_VERS_START;
+		return (prtype & DATA_VERS_SYS) == DATA_VERS_START;
 	}
 	/** @return whether this is the system field end */
 	bool vers_sys_end() const
 	{
-		return (prtype & DATA_VERSIONED) == DATA_VERS_END;
+		return (prtype & DATA_VERS_SYS) == DATA_VERS_END;
 	}
 };
 

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -653,18 +653,21 @@ struct dict_col_t{
 	bool is_nullable() const { return !(prtype & DATA_NOT_NULL); }
 
 	/** @return whether this is system field */
-	bool vers_sys_field() const { return prtype & DATA_VERSIONED; }
+	bool vers_sys_field() const
+	{
+		return vers_sys_start() || vers_sys_end();
+	}
 	/** @return whether this is system versioned */
-	bool is_versioned() const { return !(~prtype & DATA_VERSIONED); }
+	bool is_versioned() const { return (prtype & DATA_UNVERSIONED) == 0; }
 	/** @return whether this is the system version start */
 	bool vers_sys_start() const
 	{
-		return (prtype & DATA_VERSIONED) == DATA_VERS_START;
+		return (prtype & DATA_VERS_SYS) == DATA_VERS_START;
 	}
 	/** @return whether this is the system version end */
 	bool vers_sys_end() const
 	{
-		return (prtype & DATA_VERSIONED) == DATA_VERS_END;
+		return (prtype & DATA_VERS_SYS) == DATA_VERS_END;
 	}
 
 	/** @return whether this is an instantly-added column */

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -474,11 +474,16 @@ struct upd_t{
 		return(false);
 	}
 
-	/** Determine if the update affects a system versioned column. */
+	/** Determine if the update affects a system versioned column or row_end. */
 	bool affects_versioned() const
 	{
 		for (ulint i = 0; i < n_fields; i++) {
-			if (fields[i].new_val.type.vers_sys_field()) {
+			dtype_t type = fields[i].new_val.type;
+			if (type.is_versioned()) {
+				return true;
+			}
+			// versioned DELETE is UPDATE SET row_end=NOW
+			if (type.vers_sys_end()) {
 				return true;
 			}
 		}

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -2089,8 +2089,8 @@ trx_undo_report_row_operation(
 				if (!time.is_versioned()
 				    && index->table->versioned_by_id()
 				    && (!rec /* INSERT */
-					|| !update /* DELETE */
-					|| update->affects_versioned())) {
+					|| (update
+					    && update->affects_versioned()))) {
 					time.set_versioned(limit);
 				}
 			}


### PR DESCRIPTION
Some fields in system-versioned table may be unversioned.
SQL layer marks unversioned.
And this patch makes InnoDB mark unversioned too because of two reasons:
1) by default fields are versioned
2) most of fields are expected to be versioned

dtype_t::vers_sys_field(): fixed return true on row_start/row_end
dict_col_t::vers_sys_field(): fixed return true on row_start/row_end