### PR TITLE
MDEV-15062 Information Schema COLUMNS Table does not show system versioning information

### DIFF
--- a/mysql-test/suite/versioning/r/optimized.result
+++ b/mysql-test/suite/versioning/r/optimized.result
@@ -61,4 +61,9 @@ a	b
 3	4
 select * from t for system_time as of timestamp now(6) where b is NULL;
 a	b
+create or replace table t (x int with system versioning, y int);
+select * from information_schema.columns where table_name='t';
+TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	COLUMN_NAME	ORDINAL_POSITION	COLUMN_DEFAULT	IS_NULLABLE	DATA_TYPE	CHARACTER_MAXIMUM_LENGTH	CHARACTER_OCTET_LENGTH	NUMERIC_PRECISION	NUMERIC_SCALE	DATETIME_PRECISION	CHARACTER_SET_NAME	COLLATION_NAME	COLUMN_TYPE	COLUMN_KEY	EXTRA	PRIVILEGES	COLUMN_COMMENT	IS_GENERATED	GENERATION_EXPRESSION
+def	test	t	x	1	NULL	YES	int	NULL	NULL	10	0	NULL	NULL	NULL	int(11)			select,insert,update,references		NEVER	NULL
+def	test	t	y	2	NULL	YES	int	NULL	NULL	10	0	NULL	NULL	NULL	int(11)		WITHOUT SYSTEM VERSIONING	select,insert,update,references		NEVER	NULL
 drop table t;

--- a/mysql-test/suite/versioning/t/optimized.test
+++ b/mysql-test/suite/versioning/t/optimized.test
@@ -33,5 +33,4 @@ select * from t for system_time as of timestamp now(6) where b is NULL;
 create or replace table t (x int with system versioning, y int);
 select * from information_schema.columns where table_name='t';
 
-
 drop table t;

--- a/mysql-test/suite/versioning/t/optimized.test
+++ b/mysql-test/suite/versioning/t/optimized.test
@@ -30,4 +30,8 @@ insert into t values (1, 2), (3, 4);
 select * from t for system_time as of timestamp now(6);
 select * from t for system_time as of timestamp now(6) where b is NULL;
 
+create or replace table t (x int with system versioning, y int);
+select * from information_schema.columns where table_name='t';
+
+
 drop table t;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -6070,6 +6070,12 @@ static int get_schema_column_record(THD *thd, TABLE_LIST *tables,
         buf.append(STRING_WITH_LEN(", "));
       buf.append(STRING_WITH_LEN("INVISIBLE"),cs);
     }
+    if (field->vers_update_unversioned())
+    {
+      if (buf.length())
+        buf.append(STRING_WITH_LEN(", "));
+      buf.append(STRING_WITH_LEN("WITHOUT SYSTEM VERSIONING"), cs);
+    }
     table->field[17]->store(buf.ptr(), buf.length(), cs);
     table->field[19]->store(field->comment.str, field->comment.length, cs);
     if (schema_table_store_record(thd, table))


### PR DESCRIPTION
get_schema_column_record(): print 'WITHOUT SYSTEM VERSIONING` in 'EXTRA'
for such fields