### PR TITLE
MDEV-15380 Index for versioned table gets corrupt after partitioning and DELETE

### DIFF
--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -579,6 +579,26 @@ set sql_mode= '';
 update t1 set v= 1;
 Warnings:
 Warning	1906	The value specified for generated column 'v' in table 't1' ignored
+# MDEV-15380 Index for versioned table gets corrupt after partitioning and DELETE
+create or replace table t1 (pk int primary key)
+engine=myisam
+with system versioning
+partition by key() partitions 3;
+set @old_dbug=@@global.debug_dbug;
+set global debug_dbug='+d,mdev_15380_1';
+insert into t1 values (11),(12);
+set global debug_dbug='+d,mdev_15380_2';
+delete from t1 where pk in (11, 12);
+Same test but for Aria storage engine
+create or replace table t1 (pk int primary key)
+engine=aria
+with system versioning
+partition by key() partitions 3;
+set global debug_dbug='+d,mdev_15380_1';
+insert into t1 values (11),(12);
+set global debug_dbug='+d,mdev_15380_2';
+delete from t1 where pk in (11, 12);
+set global debug_dbug=@old_dbug;
 # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -492,6 +492,27 @@ subpartition by hash(v) subpartitions 3 (
 insert into t1 set i= 0;
 set sql_mode= ''; update t1 set v= 1;
 
+--echo # MDEV-15380 Index for versioned table gets corrupt after partitioning and DELETE
+create or replace table t1 (pk int primary key)
+engine=myisam
+with system versioning
+partition by key() partitions 3;
+set @old_dbug=@@global.debug_dbug;
+set global debug_dbug='+d,mdev_15380_1';
+insert into t1 values (11),(12);
+set global debug_dbug='+d,mdev_15380_2';
+delete from t1 where pk in (11, 12);
+--echo Same test but for Aria storage engine
+create or replace table t1 (pk int primary key)
+engine=aria
+with system versioning
+partition by key() partitions 3;
+set global debug_dbug='+d,mdev_15380_1';
+insert into t1 values (11),(12);
+set global debug_dbug='+d,mdev_15380_2';
+delete from t1 where pk in (11, 12);
+set global debug_dbug=@old_dbug;
+
 --echo # Test cleanup
 drop database test;
 create database test;

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -8647,6 +8647,11 @@ err_handler:
      HA_EXTRA_NO_READCHECK=5                 No readcheck on update
      HA_EXTRA_READCHECK=6                    Use readcheck (def)
 
+  HA_EXTRA_REMEMBER_POS:
+  HA_EXTRA_RESTORE_POS:
+    System versioning uses this for MyISAM and Aria tables. This is needed for
+    cases where Write in a middle of Search and Delete 'corrupts' saved rowid.
+
   4) Operations only used by temporary tables for query processing
   ----------------------------------------------------------------
   HA_EXTRA_RESET_STATE:
@@ -8706,8 +8711,6 @@ err_handler:
     Only used MyISAM, only used internally in MyISAM handler, never called
     from server level.
   HA_EXTRA_KEYREAD_CHANGE_POS:
-  HA_EXTRA_REMEMBER_POS:
-  HA_EXTRA_RESTORE_POS:
   HA_EXTRA_PRELOAD_BUFFER_SIZE:
   HA_EXTRA_CHANGE_KEY_TO_DUP:
   HA_EXTRA_CHANGE_KEY_TO_UNIQUE:
@@ -8790,6 +8793,8 @@ int ha_partition::extra(enum ha_extra_function operation)
   case HA_EXTRA_PREPARE_FOR_DROP:
   case HA_EXTRA_FLUSH_CACHE:
   case HA_EXTRA_PREPARE_FOR_ALTER_TABLE:
+  case HA_EXTRA_REMEMBER_POS:
+  case HA_EXTRA_RESTORE_POS:
   {
     DBUG_RETURN(loop_extra(operation));
   }

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -8649,8 +8649,13 @@ err_handler:
 
   HA_EXTRA_REMEMBER_POS:
   HA_EXTRA_RESTORE_POS:
-    System versioning uses this for MyISAM and Aria tables. This is needed for
-    cases where Write in a middle of Search and Delete 'corrupts' saved rowid.
+    System versioning needs this for MyISAM and Aria tables.
+    On DELETE using PRIMARY KEY:
+    1) handler::ha_index_read_map() saves rowid used for row delete/update
+    2) handler::ha_update_row() can rewrite saved rowid
+    3) handler::ha_delete_row()/handler::ha_update_row() expects saved but got
+       different rowid and operation fails
+    Using those flags prevents harmful side effect of 2)
 
   4) Operations only used by temporary tables for query processing
   ----------------------------------------------------------------

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -254,7 +254,10 @@ int TABLE::delete_row()
 
   store_record(this, record[1]);
   vers_update_end();
-  return file->ha_update_row(record[1], record[0]);
+  file->extra(HA_EXTRA_REMEMBER_POS);
+  bool res= file->ha_update_row(record[1], record[0]);
+  file->extra(HA_EXTRA_RESTORE_POS);
+  return res;
 }
 
 

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -254,10 +254,12 @@ int TABLE::delete_row()
 
   store_record(this, record[1]);
   vers_update_end();
-  file->extra(HA_EXTRA_REMEMBER_POS);
-  bool res= file->ha_update_row(record[1], record[0]);
-  file->extra(HA_EXTRA_RESTORE_POS);
-  return res;
+  int res;
+  if ((res= file->extra(HA_EXTRA_REMEMBER_POS)))
+    return res;
+  if ((res= file->ha_update_row(record[1], record[0])))
+    return res;
+  return file->extra(HA_EXTRA_RESTORE_POS);
 }
 
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1637,6 +1637,18 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
   DEBUG_SYNC(thd,"dispatch_command_before_set_time");
 
   thd->set_time();
+
+  if (DBUG_EVALUATE_IF("mdev_15380_1", true, false))
+  {
+    thd->system_time.sec= 1523466002;
+    thd->system_time.sec_part= 799571;
+  }
+  if (DBUG_EVALUATE_IF("mdev_15380_2", true, false))
+  {
+    thd->system_time.sec= 1523466004;
+    thd->system_time.sec_part= 169435;
+  }
+
   if (!(server_command_flags[command] & CF_SKIP_QUERY_ID))
     thd->set_query_id(next_query_id());
   else


### PR DESCRIPTION
In a test case Write occures between Search and Delete. This corrupts rowid
which Search saves for Delete. Patch prevents this by using of
HA_EXTRA_REMEMBER_POS and HA_EXTRA_RESTORE_POS in a partition code.

This situation possibly occures only with system versioning table and partition.
MyISAM and Aria engines are affected.

fix by midenok