### PR TITLE
MDEV-15645 Assertion `table->insert_values' failed in write_record upon REPLACE into a view with underlying versioned table

### DIFF
--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -6,5 +6,11 @@ order by x;
 id	x	current
 1	2	0
 1	3	1
+# MDEV-15645 Assertion `table->insert_values' failed in write_record upon REPLACE into a view with underlying versioned table
+create or replace table t1 (a int, b int, primary key (a), unique(b)) with system versioning;
+insert into t1 values (1,1);
+create or replace table t2 (c int);
+create or replace view v as select t1.* from t1 join t2;
+replace into v (a, b) select a, b from t1;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -9,5 +9,13 @@ replace t values (1, 3);
 select *, current_row(row_end) as current from t for system_time all
 order by x;
 
+--echo # MDEV-15645 Assertion `table->insert_values' failed in write_record upon REPLACE into a view with underlying versioned table
+create or replace table t1 (a int, b int, primary key (a), unique(b)) with system versioning;
+insert into t1 values (1,1);
+create or replace table t2 (c int);
+create or replace view v as select t1.* from t1 join t2;
+replace into v (a, b) select a, b from t1;
+
+
 drop database test;
 create database test;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1971,13 +1971,12 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
             error= table->file->ha_delete_row(table->record[1]);
           else
           {
-            DBUG_ASSERT(table->insert_values);
-            store_record(table,insert_values);
-            restore_record(table,record[1]);
+            store_record(table, record[2]);
+            restore_record(table, record[1]);
             table->vers_update_end();
             error= table->file->ha_update_row(table->record[1],
                                               table->record[0]);
-            restore_record(table,insert_values);
+            restore_record(table, record[2]);
           }
           if (error)
             goto err;

--- a/sql/sql_load.cc
+++ b/sql/sql_load.cc
@@ -431,13 +431,6 @@ int mysql_load(THD *thd, const sql_exchange *ex, TABLE_LIST *table_list,
   is_concurrent= (table_list->lock_type == TL_WRITE_CONCURRENT_INSERT);
 #endif
 
-  if (table->versioned(VERS_TIMESTAMP) && handle_duplicates == DUP_REPLACE)
-  {
-    // Additional memory may be required to create historical items.
-    if (table_list->set_insert_values(thd->mem_root))
-      DBUG_RETURN(TRUE);
-  }
-
   if (!fields_vars.elements)
   {
     Field_iterator_table_ref field_iterator;


### PR DESCRIPTION
Right temporary storage for system versioning operations is table->record[2],
not table->insert_values