### PR TITLE
MDEV-15947 ASAN heap-use-after-free in Item_ident::print or in my_strcasecmp_utf8 or unexpected ER_BAD_FIELD_ERROR upon call of stored procedure reading from versioned table

### DIFF
--- a/mysql-test/suite/versioning/r/select.result
+++ b/mysql-test/suite/versioning/r/select.result
@@ -512,6 +512,18 @@ Warnings:
 Note	1003	select `test`.`t1`.`f1` AS `f1` from `test`.`t1` FOR SYSTEM_TIME ALL join `test`.`t2` left join (`test`.`t3` left join `test`.`t4` FOR SYSTEM_TIME ALL on(`test`.`t4`.`f4` = `test`.`t2`.`f2` and `test`.`t4`.`row_end` = TIMESTAMP'2038-01-19 03:14:07.999999')) on(`test`.`t3`.`f3` = `test`.`t2`.`f2`) where `test`.`t1`.`row_end` = TIMESTAMP'2038-01-19 03:14:07.999999'
 drop view v1;
 drop table t1, t2, t3, t4;
+#
+# MDEV-15947 ASAN heap-use-after-free in Item_ident::print or in my_strcasecmp_utf8 or unexpected ER_BAD_FIELD_ERROR upon call of stored procedure reading from versioned table
+#
+create or replace table t1 (i int) with system versioning;
+create or replace procedure p() select * from t1;
+call p;
+i
+flush tables;
+call p;
+i
+drop procedure p;
+drop table t1;
 call verify_trt_dummy(34);
 No	A	B	C	D
 1	1	1	1	1

--- a/mysql-test/suite/versioning/t/select.test
+++ b/mysql-test/suite/versioning/t/select.test
@@ -326,6 +326,17 @@ select f1 from t1 join t2 left join t3 left join t4 on f3 = f4 on f3 = f2;
 drop view v1;
 drop table t1, t2, t3, t4;
 
+--echo #
+--echo # MDEV-15947 ASAN heap-use-after-free in Item_ident::print or in my_strcasecmp_utf8 or unexpected ER_BAD_FIELD_ERROR upon call of stored procedure reading from versioned table
+--echo #
+create or replace table t1 (i int) with system versioning;
+create or replace procedure p() select * from t1;
+call p;
+flush tables;
+call p;
+drop procedure p;
+drop table t1;
+
 call verify_trt_dummy(34);
 
 -- source suite/versioning/common_finish.inc

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3672,6 +3672,10 @@ public:
     lex_str->length= length;
     return lex_str;
   }
+  LEX_CSTRING *make_clex_string(const LEX_CSTRING from)
+  {
+    return make_clex_string(from.str, from.length);
+  }
 
   // Allocate LEX_STRING for character set conversion
   bool alloc_lex_string(LEX_STRING *dst, size_t length)

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -822,10 +822,10 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
       lock_type= TL_READ; // ignore TL_WRITE, history is immutable anyway
     }
 
-    LEX_CSTRING start = table->table->vers_start_field()->field_name;
-    LEX_CSTRING end = table->table->vers_end_field()->field_name;
-    const LEX_CSTRING *fstart= thd->make_clex_string(start.str, start.length);
-    const LEX_CSTRING *fend= thd->make_clex_string(end.str, end.length);
+    const LEX_CSTRING *fstart=
+        thd->make_clex_string(table->table->vers_start_field()->field_name);
+    const LEX_CSTRING *fend=
+        thd->make_clex_string(table->table->vers_end_field()->field_name);
 
     Item *row_start=
         newx Item_field(thd, &this->context, table->db.str, table->alias.str, fstart);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -822,8 +822,10 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
       lock_type= TL_READ; // ignore TL_WRITE, history is immutable anyway
     }
 
-    const LEX_CSTRING *fstart= &table->table->vers_start_field()->field_name;
-    const LEX_CSTRING *fend= &table->table->vers_end_field()->field_name;
+    LEX_CSTRING start = table->table->vers_start_field()->field_name;
+    LEX_CSTRING end = table->table->vers_end_field()->field_name;
+    const LEX_CSTRING *fstart= thd->make_clex_string(start.str, start.length);
+    const LEX_CSTRING *fend= thd->make_clex_string(end.str, end.length);
 
     Item *row_start=
         newx Item_field(thd, &this->context, table->db.str, table->alias.str, fstart);


### PR DESCRIPTION
Item_field for row_start/row_end point to a string buffer with field name.
Fix lifetime of this buffer.