### PR TITLE
 MDEV-15991 Server crashes in setup_on_expr upon calling SP or function executing DML on versioned tables

### DIFF
--- a/mysql-test/suite/versioning/r/select.result
+++ b/mysql-test/suite/versioning/r/select.result
@@ -571,6 +571,27 @@ a
 select * from t1 for system_time from @t2 to @t1;
 a
 drop table t1;
+#
+# MDEV-15991 Server crashes in setup_on_expr upon calling SP or function executing DML on versioned tables
+#
+create or replace table t1 (i int);
+insert into t1 values (1);
+create or replace procedure p(n int)
+begin
+select * from t1;
+end $
+call p(1);
+i
+1
+alter table t1 add system versioning;
+call p(2);
+i
+1
+call p(3);
+i
+1
+drop procedure p;
+drop table t1;
 call verify_trt_dummy(34);
 No	A	B	C	D
 1	1	1	1	1

--- a/mysql-test/suite/versioning/t/select.test
+++ b/mysql-test/suite/versioning/t/select.test
@@ -377,6 +377,24 @@ select * from t1 for system_time from @t1 to @t2;
 select * from t1 for system_time from @t2 to @t1;
 drop table t1;
 
+--echo #
+--echo # MDEV-15991 Server crashes in setup_on_expr upon calling SP or function executing DML on versioned tables
+--echo #
+create or replace table t1 (i int);
+insert into t1 values (1);
+--delimiter $
+create or replace procedure p(n int)
+begin
+  select * from t1;
+end $
+--delimiter ;
+call p(1);
+alter table t1 add system versioning;
+call p(2);
+call p(3);
+drop procedure p;
+drop table t1;
+
 call verify_trt_dummy(34);
 
 -- source suite/versioning/common_finish.inc

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -725,7 +725,7 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
   TABLE_LIST *table;
 
   if (!thd->stmt_arena->is_conventional() &&
-      !thd->stmt_arena->is_stmt_prepare() && !thd->stmt_arena->is_sp_execute())
+      !thd->stmt_arena->is_stmt_prepare_or_first_sp_execute())
   {
     // statement is already prepared
     DBUG_RETURN(0);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -725,7 +725,7 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
   TABLE_LIST *table;
 
   if (!thd->stmt_arena->is_conventional() &&
-      !thd->stmt_arena->is_stmt_prepare_or_first_sp_execute())
+      !thd->stmt_arena->is_stmt_prepare())
   {
     // statement is already prepared
     DBUG_RETURN(0);


### PR DESCRIPTION
Do not try to set versioning conditions on every SP call. I may work
incorrectly, but it's a general bug described in MDEV-774.
This patch makes system versioning stuff consistent with other code and
also fixes a use-after-free bug.