### PR TITLE
MDEV-16231 make DELETE use mysql_update() internally

### DIFF
--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -44,6 +44,7 @@
 #include "sql_derived.h"                        // mysql_handle_list_of_derived
                                                 // end_read_record
 #include "sql_partition.h"       // make_used_partitions_str
+#include "sql_update.h"
 
 #define MEM_STRIP_BUF_SIZE ((size_t) thd->variables.sortbuff_size)
 
@@ -342,6 +343,21 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
 	       table_list->view_db.str, table_list->view_name.str);
     DBUG_RETURN(TRUE);
   }
+
+  if (!truncate_history && table_list->table->versioned(VERS_TIMESTAMP))
+  {
+    if (update_precheck(thd, table_list))
+      DBUG_RETURN(true);
+
+    List<Item> unused1;
+    List<Item> unused2;
+    ha_rows found= 0;
+    ha_rows updated= 0;
+    DBUG_RETURN(mysql_update_inner(thd, table_list, unused1, unused2, conds,
+                                   order_list->elements, order, limit, false,
+                                   &found, &updated));
+  }
+
   table->map=1;
   query_plan.select_lex= &thd->lex->select_lex;
   query_plan.table= table;
@@ -419,9 +435,8 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
   has_triggers= (table->triggers &&
                  table->triggers->has_delete_triggers());
   if (!with_select && !using_limit && const_cond_result &&
-      (!thd->is_current_stmt_binlog_format_row() &&
-       !has_triggers)
-      && !table->versioned(VERS_TIMESTAMP))
+      !thd->is_current_stmt_binlog_format_row() && !has_triggers &&
+      !truncate_history)
   {
     /* Update the table->file->stats.records number */
     table->file->info(HA_STATUS_VARIABLE | HA_STATUS_NO_LOCK);
@@ -741,7 +756,7 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
         break;
       }
 
-      error= table->delete_row();
+      error= table->file->ha_delete_row(table->record[0]);
       if (likely(!error))
       {
 	deleted++;

--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -28,6 +28,10 @@ typedef class st_select_lex_unit SELECT_LEX_UNIT;
 bool mysql_prepare_update(THD *thd, TABLE_LIST *table_list,
                           Item **conds, uint order_num, ORDER *order);
 bool check_unique_table(THD *thd, TABLE_LIST *table_list);
+int mysql_update_inner(THD *thd, TABLE_LIST *tables, List<Item> &fields,
+                       List<Item> &values, COND *conds, uint order_num,
+                       ORDER *order, ha_rows limit, bool ignore,
+                       ha_rows *found_return, ha_rows *updated_return);
 int mysql_update(THD *thd,TABLE_LIST *tables,List<Item> &fields,
 		 List<Item> &values,COND *conds,
 		 uint order_num, ORDER *order, ha_rows limit,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8877,13 +8877,13 @@ ha_innobase::update_row(
 		const bool vers_ins_row = vers_set_fields
 			&& thd_sql_command(m_user_thd) != SQLCOM_ALTER_TABLE;
 
-		/* This is not a delete */
-		m_prebuilt->upd_node->is_delete =
-			(vers_set_fields && !vers_ins_row) ||
-			(thd_sql_command(m_user_thd) == SQLCOM_DELETE &&
-				table->versioned(VERS_TIMESTAMP))
-			? VERSIONED_DELETE
-			: NO_DELETE;
+		if (vers_set_fields && !vers_ins_row) {
+			m_prebuilt->upd_node->is_delete = TRX_ID_DELETE;
+		} else if (thd_sql_command(m_user_thd) == SQLCOM_DELETE) {
+			m_prebuilt->upd_node->is_delete = TIMESTAMP_DELETE;
+		} else {
+			m_prebuilt->upd_node->is_delete = NO_DELETE;
+		}
 
 		innobase_srv_conc_enter_innodb(m_prebuilt);
 
@@ -8993,7 +8993,7 @@ ha_innobase::delete_row(
 	m_prebuilt->upd_node->is_delete = table->versioned_write(VERS_TRX_ID)
 		&& table->vers_end_field()->is_max()
 		&& trx->id != table->vers_start_id()
-		? VERSIONED_DELETE
+		? TRX_ID_DELETE
 		: PLAIN_DELETE;
 
 	innobase_srv_conc_enter_innodb(m_prebuilt);

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -510,7 +510,8 @@ struct upd_t{
 enum delete_mode_t {
 	NO_DELETE = 0,		/*!< this operation does not delete */
 	PLAIN_DELETE,		/*!< ordinary delete */
-	VERSIONED_DELETE	/*!< update old and insert a new row */
+	TRX_ID_DELETE,		/*!< update old and insert a new row */
+	TIMESTAMP_DELETE,	/*!< treat FOREIGN check as DELETE one */
 };
 
 /* Update node structure which also implements the delete operation

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1866,7 +1866,7 @@ row_update_for_mysql(row_prebuilt_t* prebuilt)
 	ut_ad(!prebuilt->versioned_write || node->table->versioned());
 
 	if (prebuilt->versioned_write) {
-		if (node->is_delete == VERSIONED_DELETE) {
+		if (node->is_delete == TRX_ID_DELETE) {
 			node->make_versioned_delete(trx);
 		} else if (node->update->affects_versioned()) {
 			node->make_versioned_update(trx);

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3495,6 +3495,6 @@ Do not touch other fields at all.
 void upd_node_t::make_versioned_delete(const trx_t* trx)
 {
 	update->n_fields = 0;
-	is_delete = VERSIONED_DELETE;
+	is_delete = TRX_ID_DELETE;
 	make_versioned_helper(trx, table->vers_end);
 }


### PR DESCRIPTION
Perform ordinary DELETE as UPDATE. This is a pure internal thing
which doesn't have user-observable behavior.

Multi DELETE remains the same.

Trx_id versioning in InnoDB remains the same.

mysql_update(): split to mysql_update() + mysql_update_inner()

mysql_update_inner(): performs most of UPDATE job except for table opening