### PR TITLE
MDEV-16372 ER_BASE64_DECODE_ERROR upon replaying binary log with system table

### DIFF
--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -164,4 +164,23 @@ update t1 set i = 0;
 connection slave;
 connection master;
 drop table t1;
+# MDEV-16372 ER_BASE64_DECODE_ERROR upon replaying binary log with system table
+flush logs;
+set @@session.time_zone='+00:00';
+create table t1 (
+x int unsigned,
+row_start SYS_TYPE as row start invisible,
+row_end SYS_TYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 2 where x = 1;
+flush logs;
+drop table t1;
+select *, check_row(row_start, row_end) from t1 for system_time all;
+x	check_row(row_start, row_end)
+2	CURRENT ROW
+1	HISTORICAL ROW
+drop database test;
+create database test;
 include/rpl_end.inc

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -1,4 +1,5 @@
 --source suite/versioning/engines.inc
+--source suite/versioning/common.inc
 --source include/have_partition.inc
 --source include/master-slave.inc
 
@@ -132,5 +133,27 @@ update t1 set i = 0;
 sync_slave_with_master;
 connection master;
 drop table t1;
+
+--echo # MDEV-16372 ER_BASE64_DECODE_ERROR upon replaying binary log with system table
+flush logs;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $datadir= `select @@datadir`
+set @@session.time_zone='+00:00';
+replace_result $sys_datatype_expl SYS_TYPE;
+eval create table t1 (
+  x int unsigned,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 2 where x = 1;
+flush logs;
+drop table t1;
+--exec $MYSQL_BINLOG -v $datadir/$binlog_file | $MYSQL test
+select *, check_row(row_start, row_end) from t1 for system_time all;
+
+drop database test;
+create database test;
 
 --source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3883,7 +3883,10 @@ bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
   if (print_event_info->verbose)
   {
     if (ev->print_verbose(file, print_event_info))
-      goto err;
+    {
+      delete ev;
+      return true;
+    }
   }
   else
   {
@@ -3893,7 +3896,7 @@ bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
                           MYF(MY_WME | MY_NABP)))
     {
       delete ev;
-      goto err;
+      return true;
     }
 
     error= ev->print_verbose(&tmp_cache, print_event_info);
@@ -3901,7 +3904,7 @@ bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
     if (unlikely(error))
     {
       delete ev;
-      goto err;
+      return true;
     }
   }
 #else

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3678,6 +3678,7 @@ bool Log_event::print_base64(IO_CACHE* file,
 {
   uchar *ptr= (uchar *)temp_buf;
   uint32 size= uint4korr(ptr + EVENT_LEN_OFFSET);
+  bool need_delimiter= false;
   DBUG_ENTER("Log_event::print_base64");
 
   if (is_flashback)
@@ -3740,14 +3741,22 @@ bool Log_event::print_base64(IO_CACHE* file,
       DBUG_ASSERT(0);
     }
 
-    if (my_b_tell(file) == 0)
+    if (!print_event_info->base64_starter_printed)
+    {
+      print_event_info->base64_starter_printed= true;
       if (unlikely(my_b_write_string(file, "\nBINLOG '\n")))
         error= 1;
+    }
     if (likely(!error) && unlikely(my_b_printf(file, "%s\n", tmp_str)))
       error= 1;
     if (!more && likely(!error))
+    {
+      print_event_info->base64_starter_printed= false;
       if (unlikely(my_b_printf(file, "'%s\n", print_event_info->delimiter)))
         error= 1;
+    }
+    else
+      need_delimiter= true;
     my_free(tmp_str);
     if (unlikely(error))
       goto err;
@@ -3840,6 +3849,12 @@ bool Log_event::print_base64(IO_CACHE* file,
       ev->need_flashback_review= need_flashback_review;
       if (print_event_info->verbose)
       {
+        if (need_delimiter)
+        {
+          print_event_info->base64_starter_printed= false;
+          if (unlikely(my_b_printf(file, "'%s\n", print_event_info->delimiter)))
+            goto err;
+        }
         if (ev->print_verbose(file, print_event_info))
           goto err;
       }
@@ -3864,7 +3879,16 @@ bool Log_event::print_base64(IO_CACHE* file,
       }
 #else
       if (print_event_info->verbose)
-        error= ev->print_verbose(file, print_event_info);
+      {
+        error= 0;
+        if (need_delimiter)
+        {
+          print_event_info->base64_starter_printed= false;
+          error= my_b_printf(file, "'%s\n", print_event_info->delimiter);
+        }
+        if (likely(!error))
+          error= ev->print_verbose(file, print_event_info);
+      }
       else
         ev->count_row_events(print_event_info);
 #endif
@@ -5996,9 +6020,6 @@ bool Start_log_event_v3::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
       print_event_info->base64_output_mode != BASE64_OUTPUT_NEVER &&
       !print_event_info->short_form)
   {
-    if (print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS)
-      if (my_b_printf(&cache, "BINLOG '\n"))
-        goto err;
     if (print_base64(&cache, print_event_info, FALSE))
       goto err;
     print_event_info->printed_fd_event= TRUE;
@@ -14687,6 +14708,7 @@ st_print_event_info::st_print_event_info()
   domain_id_printed= false;
   allow_parallel= true;
   allow_parallel_printed= false;
+  base64_starter_printed= false;
   found_row_event= false;
   print_row_count= false;
   short_form= false;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -6032,8 +6032,12 @@ bool Start_log_event_v3::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
       !print_event_info->short_form)
   {
     if (print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS)
+    {
       if (my_b_printf(&cache, "BINLOG '\n"))
         goto err;
+      else
+        print_event_info->inside_binlog= true;
+    }
     if (print_base64(&cache, print_event_info, FALSE))
       goto err;
     print_event_info->printed_fd_event= TRUE;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3672,6 +3672,10 @@ void free_table_map_log_event(Table_map_log_event *event)
   delete event;
 }
 
+static
+bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
+                    Rows_log_event *ev);
+
 bool Log_event::print_base64(IO_CACHE* file,
                              PRINT_EVENT_INFO* print_event_info,
                              bool more)
@@ -3868,9 +3872,9 @@ err:
 }
 
 
-bool Log_event::describe_event(IO_CACHE* file,
-                               PRINT_EVENT_INFO* print_event_info,
-                               Rows_log_event *ev)
+static
+bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
+                    Rows_log_event *ev)
 {
   bool error= 0;
 

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -864,6 +864,7 @@ typedef struct st_print_event_info
   bool domain_id_printed;
   bool allow_parallel;
   bool allow_parallel_printed;
+  bool base64_starter_printed;
   bool found_row_event;
   bool print_row_count;
   /* Settings on how to print the events */

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1270,9 +1270,6 @@ public:
                     bool is_more);
   bool print_base64(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
                     bool is_more);
-  static
-  bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
-                      Rows_log_event *ev);
 #endif /* MYSQL_SERVER */
 
   /* The following code used for Flashback */

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -880,6 +880,7 @@ typedef struct st_print_event_info
     statement for it.
   */
   bool skip_replication;
+  bool inside_binlog;
 
   /*
      These two caches are used by the row-based replication events to

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -864,7 +864,6 @@ typedef struct st_print_event_info
   bool domain_id_printed;
   bool allow_parallel;
   bool allow_parallel_printed;
-  bool base64_starter_printed;
   bool found_row_event;
   bool print_row_count;
   /* Settings on how to print the events */

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -51,6 +51,7 @@
 #endif
 
 #include "rpl_gtid.h"
+#include "sql_array.h"
 
 /* Forward declarations */
 #ifndef MYSQL_CLIENT
@@ -817,6 +818,8 @@ enum enum_base64_output_mode {
 
 bool copy_event_cache_to_string_and_reinit(IO_CACHE *cache, LEX_STRING *to);
 
+class Rows_log_event;
+
 /*
   A structure for mysqlbinlog to know how to print events
 
@@ -881,6 +884,7 @@ typedef struct st_print_event_info
   */
   bool skip_replication;
   bool inside_binlog;
+  Dynamic_array<Rows_log_event *> verbose_events;
 
   /*
      These two caches are used by the row-based replication events to
@@ -1266,6 +1270,9 @@ public:
                     bool is_more);
   bool print_base64(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
                     bool is_more);
+  static
+  bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
+                      Rows_log_event *ev);
 #endif /* MYSQL_SERVER */
 
   /* The following code used for Flashback */


### PR DESCRIPTION
mysqlbinlog verbose mode in case of multi-row BINLOG statement caches events for verbose output and prints it after BINLOG statement is finished.

BINLOG statement must not be splitted into multiple statements because row events require Table_map_event.

Tested on all suites.

[Fixes tempesta-tech/mariadb#500] 