### PR TITLE
MDEV-16429: Assertion `!table || (!table->read_set || bitmap_is_set(t…

### DIFF
--- a/mysql-test/main/partition_error.result
+++ b/mysql-test/main/partition_error.result
@@ -1866,3 +1866,12 @@ pUpTo10	p-10sp1	This is a long comment (2050 ascii characters)   50 pUpTo10 part
 pMax	pMaxsp0	This is a long comment (2050 ascii characters)   50 pMax partition comment .80-!
 pMax	pMaxsp1	This is a long comment (2050 ascii characters)   50 pMax partition comment .80-!
 DROP TABLE t1;
+CREATE OR REPLACE TABLE t1 (
+pk INT PRIMARY KEY,
+c CHAR(3) NOT NULL,
+v CHAR(4) AS (c) VIRTUAL
+) WITH SYSTEM VERSIONING PARTITION BY HASH(pk);
+INSERT INTO t1 (pk,c) VALUES (1,'foo'),(2,'bar');
+UPDATE t1 SET v = 'qux' WHERE pk = 2;
+ERROR HY000: The value specified for generated column 'v' in table 't1' ignored
+DROP TABLE t1;

--- a/mysql-test/main/partition_error.test
+++ b/mysql-test/main/partition_error.test
@@ -2074,3 +2074,21 @@ SELECT PARTITION_NAME, SUBPARTITION_NAME, PARTITION_COMMENT FROM INFORMATION_SCH
 WHERE TABLE_NAME = 't1' AND TABLE_SCHEMA = 'test';
 
 DROP TABLE t1;
+
+#
+# MDEV-16429
+# Assertion `!table || (!table->read_set
+#                       || bitmap_is_set(table->read_set, field_index))'
+# fails upon attempt to update virtual column on partitioned versioned table
+#
+CREATE OR REPLACE TABLE t1 (
+  pk INT PRIMARY KEY,
+  c CHAR(3) NOT NULL,
+  v CHAR(4) AS (c) VIRTUAL
+) WITH SYSTEM VERSIONING PARTITION BY HASH(pk);
+
+INSERT INTO t1 (pk,c) VALUES (1,'foo'),(2,'bar');
+-- error ER_WARNING_NON_DEFAULT_VALUE_FOR_GENERATED_COLUMN
+UPDATE t1 SET v = 'qux' WHERE pk = 2;
+
+DROP TABLE t1;

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -844,7 +844,7 @@ public:
   int change_partitions_to_open(List<String> *partition_names);
   int open_read_partitions(char *name_buff, size_t name_buff_size);
   virtual int extra(enum ha_extra_function operation);
-  virtual int extra_opt(enum ha_extra_function operation, ulong cachesize);
+  virtual int extra_opt(enum ha_extra_function operation, ulong arg);
   virtual int reset(void);
   virtual uint count_query_cache_dependant_tables(uint8 *tables_type);
   virtual my_bool
@@ -864,6 +864,7 @@ private:
                                           **block_table,
                                           handler *file, uint *n);
   static const uint NO_CURRENT_PART_ID= NOT_A_PARTITION_ID;
+  int loop_partitions(int f(handler *, void *), void *param);
   int loop_extra(enum ha_extra_function operation);
   int loop_extra_alter(enum ha_extra_function operations);
   void late_extra_cache(uint partition_id);

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -854,6 +854,8 @@ public:
                                           uint *n);
 
 private:
+  typedef int handler_callback(handler *, void *);
+
   my_bool reg_query_cache_dependant_table(THD *thd,
                                           char *engine_key,
                                           uint engine_key_len,
@@ -864,8 +866,7 @@ private:
                                           **block_table,
                                           handler *file, uint *n);
   static const uint NO_CURRENT_PART_ID= NOT_A_PARTITION_ID;
-  int loop_partitions(int f(handler *, void *), void *param);
-  int loop_extra(enum ha_extra_function operation);
+  int loop_partitions(handler_callback callback, void *param);
   int loop_extra_alter(enum ha_extra_function operations);
   void late_extra_cache(uint partition_id);
   void late_extra_no_cache(uint partition_id);

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3096,7 +3096,7 @@ public:
   bool keyread_enabled() { return keyread < MAX_KEY; }
   int ha_start_keyread(uint idx)
   {
-    int res= keyread_enabled() ? 0 : extra(HA_EXTRA_KEYREAD);
+    int res= keyread_enabled() ? 0 : extra_opt(HA_EXTRA_KEYREAD, idx);
     keyread= idx;
     return res;
   }
@@ -3600,7 +3600,7 @@ public:
   { return 0; }
   virtual int extra(enum ha_extra_function operation)
   { return 0; }
-  virtual int extra_opt(enum ha_extra_function operation, ulong cache_size)
+  virtual int extra_opt(enum ha_extra_function operation, ulong arg)
   { return extra(operation); }
 
   /**


### PR DESCRIPTION
…able->read_set, field_index))' fails upon attempt to update virtual column on partitioned versioned table

* update keyread state of underlying handlers recursively

test suites run: main,parts,versioning