### PR TITLE
MDEV-16481: set global system_versioning_asof=sf() crashes in specific case

### DIFF
--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -45,7 +45,6 @@ ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
 Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
 system_versioning_asof	1991-11-11 11:11:11.111111
@@ -71,7 +70,6 @@ DEFAULT
 # SESSION @@system_versioning_asof
 set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
@@ -189,6 +187,12 @@ select * from t as empty;
 a
 disconnect subcon;
 connection default;
+# MDEV-16481: set global system_versioning_asof=sf() crashes in specific case
+# Using global variable inside a stored function should not crash
+create or replace function now_global() returns timestamp
+return  CONVERT_TZ(now(), @@session.time_zone, @@global.time_zone);
+set global system_versioning_asof= now_global();
+drop function now_global;
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
 set global system_versioning_asof= "DEFAULT";

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -133,6 +133,13 @@ select * from t as empty;
 --disconnect subcon
 --connection default
 
+--echo # MDEV-16481: set global system_versioning_asof=sf() crashes in specific case
+--echo # Using global variable inside a stored function should not crash
+create or replace function now_global() returns timestamp
+  return  CONVERT_TZ(now(), @@session.time_zone, @@global.time_zone);
+set global system_versioning_asof= now_global();
+drop function now_global;
+
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
 set global system_versioning_asof= "DEFAULT";

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -290,6 +290,7 @@ public:
     plugin_ref *plugins;                ///< for Sys_var_pluginlist
     Time_zone *time_zone;               ///< for Sys_var_tz
     LEX_STRING string_value;            ///< for Sys_var_charptr and others
+    MYSQL_TIME time;                    ///< for Sys_var_vers_asof
     const void *ptr;                    ///< for Sys_var_struct
   } save_result;
   LEX_CSTRING base; /**< for structured variables, like keycache_name.variable_name */

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -2623,12 +2623,14 @@ public:
   virtual bool do_check(THD *thd, set_var *var)
   {
     if (!Sys_var_enum::do_check(thd, var))
-      return false;
-    MYSQL_TIME ltime;
-    bool res= var->value->get_date(&ltime, 0);
-    if (!res)
     {
-      var->save_result.ulonglong_value= SYSTEM_TIME_AS_OF;
+      var->save_result.time.time_type= MYSQL_TIMESTAMP_NONE;
+      return false;
+    }
+    bool res= var->value->get_date(&var->save_result.time, 0);
+    if (res)
+    {
+      var->save_result.time.time_type= MYSQL_TIMESTAMP_ERROR;
     }
     return res;
   }
@@ -2636,24 +2638,25 @@ public:
 private:
   bool update(set_var *var, vers_asof_timestamp_t &out, system_variables& pool)
   {
+    MYSQL_TIME &ltime= var->save_result.time;
     bool res= false;
-    out.type= static_cast<enum_var_type>(var->save_result.ulonglong_value);
-    if (out.type == SYSTEM_TIME_AS_OF)
+
+    if (!var->value || ltime.time_type == MYSQL_TIMESTAMP_NONE)
     {
-      if (var->value)
-      {
-        MYSQL_TIME ltime;
-        uint error;
-        res= var->value->get_date(&ltime, 0);
-        out.unix_time= pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
-        out.second_part= ltime.second_part;
-        res|= (error != 0);
-      }
-      else // set DEFAULT from global var
-      {
-        out= global_var(vers_asof_timestamp_t);
-        res= false;
-      }
+      out.type= SYSTEM_TIME_UNSPECIFIED;
+    }
+
+    if (var->value && ltime.time_type >= 0) // any valid value is ok
+    {
+      uint error;
+      out.type       = SYSTEM_TIME_AS_OF;
+      out.unix_time  = pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
+      out.second_part= ltime.second_part;
+      res= (error != 0);
+    }
+    else // set DEFAULT from global var
+    {
+      out= global_var(vers_asof_timestamp_t);
     }
     return res;
   }


### PR DESCRIPTION
* sys_vars.h: add `MYSQL_TIME` field to `set_var::save_result`
* sys_vars.ic: get rid of calling `var->value->get_date()` from `Sys_var_vers_asof::update()`
* versioning.sysvars: add test; remove double warning

test run: `versioning.sysvars`