### PR TITLE
MDEV-16546 System versioning setting to allow history modification

### DIFF
--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -205,12 +205,31 @@ show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2
 set system_versioning_modify_history= on;
-update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 01:00' where a= 2;
-update t set row_start= '1999-01-01 00:00', row_end= '1999-01-01 01:00' where a= 1;
+set time_zone='+00:00';
+# UPDATE of current row
+update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 00:00' where a= 2;
+# UPDATE of historical row
+update t set row_start= '1999-01-01 01:00', row_end= '1999-01-01 00:00' where a= 1;
+# INSERT historical row
 insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
 select *, row_start, row_end from t for system_time all;
 a	row_start	row_end
-2	1998-01-01 00:00:00.000000	1998-01-01 01:00:00.000000
-1	1999-01-01 00:00:00.000000	1999-01-01 01:00:00.000000
+2	1998-01-01 00:00:00.000000	1998-01-01 00:00:00.000000
+1	1999-01-01 01:00:00.000000	1999-01-01 00:00:00.000000
 3	2000-01-01 00:00:00.000000	2000-01-01 01:00:00.000000
-drop table t;
+# normal INSERT
+insert into t (a) values (4);
+select * from t;
+a
+4
+# normal UPDATE
+update t set a= 5;
+select *, check_row(row_start, row_end) from t for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end < row_start
+2	ERROR: row_end == row_start
+3	HISTORICAL ROW
+4	HISTORICAL ROW
+5	CURRENT ROW
+drop database test;
+create database test;

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -204,7 +204,9 @@ set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2
+#
 # MDEV-16546 System versioning setting to allow history modification
+#
 set system_versioning_modify_history= on;
 create or replace table t (
 a int primary key,
@@ -234,6 +236,13 @@ a	check_row(row_start, row_end)
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
+## Multi-row INSERT
+create or replace table t2 like t;
+insert into t2 (a, row_start, row_end) values (1, @s1, @e1), (2, @s2, @e2);
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end == row_start
+2	ERROR: row_end < row_start
 ## INSERT..SELECT
 create or replace table t2 like t;
 insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -234,6 +234,16 @@ a	check_row(row_start, row_end)
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
+## INSERT..SELECT
+create or replace table t2 like t;
+insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
+select *, check_row(row_start, row_end) from t for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end < row_start
+2	ERROR: row_end == row_start
+3	HISTORICAL ROW
+4	HISTORICAL ROW
+5	CURRENT ROW
 ## Honor secure_timestamp option
 insert into t (a, row_start, row_end) values (6, @s3, @e3);
 ERROR HY000: The value specified for generated column 'row_start' in table 't' ignored

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -204,4 +204,13 @@ set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2
+set system_versioning_modify_history= on;
+update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 01:00' where a= 2;
+update t set row_start= '1999-01-01 00:00', row_end= '1999-01-01 01:00' where a= 1;
+insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
+select *, row_start, row_end from t for system_time all;
+a	row_start	row_end
+2	1998-01-01 00:00:00.000000	1998-01-01 01:00:00.000000
+1	1999-01-01 00:00:00.000000	1999-01-01 01:00:00.000000
+3	2000-01-01 00:00:00.000000	2000-01-01 01:00:00.000000
 drop table t;

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -237,13 +237,29 @@ a	check_row(row_start, row_end)
 ## INSERT..SELECT
 create or replace table t2 like t;
 insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
-select *, check_row(row_start, row_end) from t for system_time all order by a;
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 a	check_row(row_start, row_end)
 1	ERROR: row_end < row_start
 2	ERROR: row_end == row_start
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
+## Multi-UPDATE
+update t, t2 set t.row_start= @s1, t2.row_start= @s1, t.row_end= @s1, t2.row_end= @s1 where t.a > 3 and t2.a > 3;
+select *, check_row(row_start, row_end) from t for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end < row_start
+2	ERROR: row_end == row_start
+3	HISTORICAL ROW
+4	ERROR: row_end == row_start
+5	ERROR: row_end == row_start
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end < row_start
+2	ERROR: row_end == row_start
+3	HISTORICAL ROW
+4	ERROR: row_end == row_start
+5	ERROR: row_end == row_start
 ## Honor secure_timestamp option
 insert into t (a, row_start, row_end) values (6, @s3, @e3);
 ERROR HY000: The value specified for generated column 'row_start' in table 't' ignored

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -101,6 +101,8 @@ set system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 equal
 1
+set global time_zone= DEFAULT;
+set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;
@@ -202,19 +204,22 @@ set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2
+# MDEV-16546 System versioning setting to allow history modification
 set system_versioning_modify_history= on;
-set time_zone='+00:00';
+create or replace table t (
+a int,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time (row_start, row_end)
+) with system versioning;
+insert into t values (1);
+update t set a= 2;
 # UPDATE of current row
-update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 00:00' where a= 2;
+update t set row_start= @s1, row_end= @e1 where a= 2;
 # UPDATE of historical row
-update t set row_start= '1999-01-01 01:00', row_end= '1999-01-01 00:00' where a= 1;
+update t set row_start= @s2, row_end= @e2 where a= 1;
 # INSERT historical row
-insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
-select *, row_start, row_end from t for system_time all;
-a	row_start	row_end
-2	1998-01-01 00:00:00.000000	1998-01-01 00:00:00.000000
-1	1999-01-01 01:00:00.000000	1999-01-01 00:00:00.000000
-3	2000-01-01 00:00:00.000000	2000-01-01 01:00:00.000000
+insert into t (a, row_start, row_end) values (3, @s3, @e3);
 # normal INSERT
 insert into t (a) values (4);
 select * from t;

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -207,17 +207,17 @@ Feature_system_versioning	2
 # MDEV-16546 System versioning setting to allow history modification
 set system_versioning_modify_history= on;
 create or replace table t (
-a int,
+a int primary key,
 row_start SYS_DATATYPE as row start invisible,
 row_end SYS_DATATYPE as row end invisible,
 period for system_time (row_start, row_end)
 ) with system versioning;
 insert into t values (1);
 update t set a= 2;
-## UPDATE of current row
-update t set row_start= @s1, row_end= @e1 where a= 2;
 ## UPDATE of historical row
-update t set row_start= @s2, row_end= @e2 where a= 1;
+update t set row_start= @s1, row_end= @e1 where a= 1;
+## UPDATE of current row
+update t set row_start= @s2, row_end= @e2 where a= 2;
 ## INSERT historical row
 insert into t (a, row_start, row_end) values (3, @s3, @e3);
 ## normal INSERT
@@ -229,8 +229,8 @@ a
 update t set a= 5;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
 a	check_row(row_start, row_end)
-1	ERROR: row_end < row_start
-2	ERROR: row_end == row_start
+1	ERROR: row_end == row_start
+2	ERROR: row_end < row_start
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
@@ -239,8 +239,8 @@ create or replace table t2 like t;
 insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
 select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 a	check_row(row_start, row_end)
-1	ERROR: row_end < row_start
-2	ERROR: row_end == row_start
+1	ERROR: row_end == row_start
+2	ERROR: row_end < row_start
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
@@ -248,12 +248,21 @@ a	check_row(row_start, row_end)
 update t, t2 set t.row_start= @s1, t2.row_start= @s1, t.row_end= @s1, t2.row_end= @s1 where t.a > 3 and t2.a > 3;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
 a	check_row(row_start, row_end)
-1	ERROR: row_end < row_start
-2	ERROR: row_end == row_start
+1	ERROR: row_end == row_start
+2	ERROR: row_end < row_start
 3	HISTORICAL ROW
 4	ERROR: row_end == row_start
 5	ERROR: row_end == row_start
 select *, check_row(row_start, row_end) from t2 for system_time all order by a;
+a	check_row(row_start, row_end)
+1	ERROR: row_end == row_start
+2	ERROR: row_end < row_start
+3	HISTORICAL ROW
+4	ERROR: row_end == row_start
+5	ERROR: row_end == row_start
+## REPLACE
+replace t (a, row_start, row_end) values (1, @s3, @e1), (2, @e2, @e2);
+select *, check_row(row_start, row_end) from t for system_time all order by a;
 a	check_row(row_start, row_end)
 1	ERROR: row_end < row_start
 2	ERROR: row_end == row_start

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -214,18 +214,18 @@ period for system_time (row_start, row_end)
 ) with system versioning;
 insert into t values (1);
 update t set a= 2;
-# UPDATE of current row
+## UPDATE of current row
 update t set row_start= @s1, row_end= @e1 where a= 2;
-# UPDATE of historical row
+## UPDATE of historical row
 update t set row_start= @s2, row_end= @e2 where a= 1;
-# INSERT historical row
+## INSERT historical row
 insert into t (a, row_start, row_end) values (3, @s3, @e3);
-# normal INSERT
+## normal INSERT
 insert into t (a) values (4);
 select * from t;
 a
 4
-# normal UPDATE
+## normal UPDATE
 update t set a= 5;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
 a	check_row(row_start, row_end)
@@ -234,5 +234,25 @@ a	check_row(row_start, row_end)
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 5	CURRENT ROW
+## Honor secure_timestamp option
+insert into t (a, row_start, row_end) values (6, @s3, @e3);
+ERROR HY000: The value specified for generated column 'row_start' in table 't' ignored
+show warnings;
+Level	Code	Message
+Warning	4145	Modifying history is prohibited, set `secure_timestamp` to NO or SUPER
+Error	1906	The value specified for generated column 'row_start' in table 't' ignored
+Error	1906	The value specified for generated column 'row_end' in table 't' ignored
+insert into t (a, row_start, row_end) values (7, @s3, @e3);
+ERROR HY000: The value specified for generated column 'row_start' in table 't' ignored
+show warnings;
+Level	Code	Message
+Warning	4145	Modifying history is prohibited, set `secure_timestamp` to NO or SUPER
+Error	1906	The value specified for generated column 'row_start' in table 't' ignored
+Error	1906	The value specified for generated column 'row_end' in table 't' ignored
+insert into t (a, row_start, row_end) values (8, @s3, @e3);
+create user nobody;
+use test;
+insert into t (a, row_start, row_end) values (9, @s3, @e3);
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -101,8 +101,6 @@ set system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 equal
 1
-set global time_zone= DEFAULT;
-set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;

--- a/mysql-test/suite/versioning/t/sysvars.inc
+++ b/mysql-test/suite/versioning/t/sysvars.inc
@@ -1,0 +1,20 @@
+--disable_query_log
+if ($MTR_COMBINATION_TRX_ID)
+{
+  set @s1= 1;
+  set @e1= 1;
+  set @s2= 3;
+  set @e2= 2;
+  set @s3= 4;
+  set @e3= 5;
+}
+if (!$MTR_COMBINATION_TRX_ID)
+{
+  set @s1= '1998-01-01 00:00';
+  set @e1= '1998-01-01 00:00';
+  set @s2= '1999-01-01 01:00';
+  set @e2= '1999-01-01 00:00';
+  set @s3= '2000-01-01 00:00';
+  set @e3= '2000-01-01 01:00';
+}
+--enable_query_log

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -151,4 +151,10 @@ set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 
+set system_versioning_modify_history= on;
+update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 01:00' where a= 2;
+update t set row_start= '1999-01-01 00:00', row_end= '1999-01-01 01:00' where a= 1;
+insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
+select *, row_start, row_end from t for system_time all;
+
 drop table t;

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -1,3 +1,5 @@
+--source suite/versioning/common.inc
+
 create table t (a int) with system versioning;
 set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
@@ -152,9 +154,16 @@ set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 
 set system_versioning_modify_history= on;
+set time_zone='+00:00';
 update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 01:00' where a= 2;
 update t set row_start= '1999-01-01 00:00', row_end= '1999-01-01 01:00' where a= 1;
 insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
 select *, row_start, row_end from t for system_time all;
+insert into t (a) values (4);
+select * from t;
+update t set a= 5;
+select *, check_row(row_start, row_end) from t for system_time all where a >= 4;
 
-drop table t;
+drop database test;
+create database test;
+

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -1,5 +1,3 @@
---source suite/versioning/common.inc
-
 create table t (a int) with system versioning;
 set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
@@ -153,6 +151,8 @@ set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 
+--source suite/versioning/engines.inc
+--source suite/versioning/common.inc
 set system_versioning_modify_history= on;
 set time_zone='+00:00';
 --echo # UPDATE of current row

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -180,6 +180,10 @@ select * from t;
 --echo ## normal UPDATE
 update t set a= 5;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
+--echo ## INSERT..SELECT
+create or replace table t2 like t;
+insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
+select *, check_row(row_start, row_end) from t for system_time all order by a;
 
 --echo ## Honor secure_timestamp option
 --let $restart_parameters= --secure-timestamp=YES --system-versioning-modify-history=on

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -154,6 +154,7 @@ show status like "Feature_system_versioning";
 --echo # MDEV-16546 System versioning setting to allow history modification
 --source suite/versioning/engines.inc
 --source suite/versioning/common.inc
+--source suite/versioning/t/sysvars.inc
 set system_versioning_modify_history= on;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
@@ -167,39 +168,41 @@ eval create or replace table t (
 insert into t values (1);
 update t set a= 2;
 
---disable_query_log
-if ($MTR_COMBINATION_TRX_ID)
-{
-  set @s1= 1;
-  set @e1= 1;
-  set @s2= 3;
-  set @e2= 2;
-  set @s3= 4;
-  set @e3= 5;
-}
-if (!$MTR_COMBINATION_TRX_ID)
-{
-  set @s1= '1998-01-01 00:00';
-  set @e1= '1998-01-01 00:00';
-  set @s2= '1999-01-01 01:00';
-  set @e2= '1999-01-01 00:00';
-  set @s3= '2000-01-01 00:00';
-  set @e3= '2000-01-01 01:00';
-}
---enable_query_log
-
---echo # UPDATE of current row
+--echo ## UPDATE of current row
 update t set row_start= @s1, row_end= @e1 where a= 2;
---echo # UPDATE of historical row
+--echo ## UPDATE of historical row
 update t set row_start= @s2, row_end= @e2 where a= 1;
---echo # INSERT historical row
+--echo ## INSERT historical row
 insert into t (a, row_start, row_end) values (3, @s3, @e3);
---echo # normal INSERT
+--echo ## normal INSERT
 insert into t (a) values (4);
 select * from t;
---echo # normal UPDATE
+--echo ## normal UPDATE
 update t set a= 5;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
+
+--echo ## Honor secure_timestamp option
+--let $restart_parameters= --secure-timestamp=YES --system-versioning-modify-history=on
+--source include/restart_mysqld.inc
+--source suite/versioning/t/sysvars.inc
+--error ER_WARNING_NON_DEFAULT_VALUE_FOR_GENERATED_COLUMN
+insert into t (a, row_start, row_end) values (6, @s3, @e3);
+show warnings;
+--let $restart_parameters= --secure-timestamp=REPLICATION --system-versioning-modify-history=on
+--source include/restart_mysqld.inc
+--source suite/versioning/t/sysvars.inc
+--error ER_WARNING_NON_DEFAULT_VALUE_FOR_GENERATED_COLUMN
+insert into t (a, row_start, row_end) values (7, @s3, @e3);
+show warnings;
+--let $restart_parameters= --secure-timestamp=SUPER --system-versioning-modify-history=on
+--source include/restart_mysqld.inc
+--source suite/versioning/t/sysvars.inc
+insert into t (a, row_start, row_end) values (8, @s3, @e3);
+create user nobody;
+change_user nobody;
+use test;
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+insert into t (a, row_start, row_end) values (9, @s3, @e3);
 
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -183,7 +183,11 @@ select *, check_row(row_start, row_end) from t for system_time all order by a;
 --echo ## INSERT..SELECT
 create or replace table t2 like t;
 insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
+--echo ## Multi-UPDATE
+update t, t2 set t.row_start= @s1, t2.row_start= @s1, t.row_end= @s1, t2.row_end= @s1 where t.a > 3 and t2.a > 3;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 
 --echo ## Honor secure_timestamp option
 --let $restart_parameters= --secure-timestamp=YES --system-versioning-modify-history=on

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -151,7 +151,9 @@ set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 
+--echo #
 --echo # MDEV-16546 System versioning setting to allow history modification
+--echo #
 --source suite/versioning/engines.inc
 --source suite/versioning/common.inc
 --source suite/versioning/t/sysvars.inc
@@ -175,12 +177,16 @@ update t set row_start= @s2, row_end= @e2 where a= 2;
 --echo ## INSERT historical row
 insert into t (a, row_start, row_end) values (3, @s3, @e3);
 --echo ## normal INSERT
-# TODO: implement DEFAULT values for row_start, row_end
+# TODO: implement DEFAULT values for row_start, row_end. Hard to do now because of TRX_ID.
 insert into t (a) values (4);
 select * from t;
 --echo ## normal UPDATE
 update t set a= 5;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
+--echo ## Multi-row INSERT
+create or replace table t2 like t;
+insert into t2 (a, row_start, row_end) values (1, @s1, @e1), (2, @s2, @e2);
+select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 --echo ## INSERT..SELECT
 create or replace table t2 like t;
 insert into t2 (a, row_start, row_end) select a, row_start, row_end from t for system_time all;
@@ -190,10 +196,8 @@ update t, t2 set t.row_start= @s1, t2.row_start= @s1, t.row_end= @s1, t2.row_end
 select *, check_row(row_start, row_end) from t for system_time all order by a;
 select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 --echo ## REPLACE
-select *, row_start, row_end from t for system_time all;
 replace t (a, row_start, row_end) values (1, @s3, @e1), (2, @e2, @e2);
 select *, check_row(row_start, row_end) from t for system_time all order by a;
-select *, row_start, row_end from t for system_time all;
 
 --echo ## Honor secure_timestamp option
 --let $restart_parameters= --secure-timestamp=YES --system-versioning-modify-history=on

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -151,17 +151,49 @@ set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 
+--echo # MDEV-16546 System versioning setting to allow history modification
 --source suite/versioning/engines.inc
 --source suite/versioning/common.inc
 set system_versioning_modify_history= on;
-set time_zone='+00:00';
+
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table t (
+  a int,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end)
+) with system versioning;
+
+insert into t values (1);
+update t set a= 2;
+
+--disable_query_log
+if ($MTR_COMBINATION_TRX_ID)
+{
+  set @s1= 1;
+  set @e1= 1;
+  set @s2= 3;
+  set @e2= 2;
+  set @s3= 4;
+  set @e3= 5;
+}
+if (!$MTR_COMBINATION_TRX_ID)
+{
+  set @s1= '1998-01-01 00:00';
+  set @e1= '1998-01-01 00:00';
+  set @s2= '1999-01-01 01:00';
+  set @e2= '1999-01-01 00:00';
+  set @s3= '2000-01-01 00:00';
+  set @e3= '2000-01-01 01:00';
+}
+--enable_query_log
+
 --echo # UPDATE of current row
-update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 00:00' where a= 2;
+update t set row_start= @s1, row_end= @e1 where a= 2;
 --echo # UPDATE of historical row
-update t set row_start= '1999-01-01 01:00', row_end= '1999-01-01 00:00' where a= 1;
+update t set row_start= @s2, row_end= @e2 where a= 1;
 --echo # INSERT historical row
-insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
-select *, row_start, row_end from t for system_time all;
+insert into t (a, row_start, row_end) values (3, @s3, @e3);
 --echo # normal INSERT
 insert into t (a) values (4);
 select * from t;

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -155,14 +155,19 @@ show status like "Feature_system_versioning";
 
 set system_versioning_modify_history= on;
 set time_zone='+00:00';
-update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 01:00' where a= 2;
-update t set row_start= '1999-01-01 00:00', row_end= '1999-01-01 01:00' where a= 1;
+--echo # UPDATE of current row
+update t set row_start= '1998-01-01 00:00', row_end= '1998-01-01 00:00' where a= 2;
+--echo # UPDATE of historical row
+update t set row_start= '1999-01-01 01:00', row_end= '1999-01-01 00:00' where a= 1;
+--echo # INSERT historical row
 insert into t (a, row_start, row_end) values (3, '2000-01-01 00:00', '2000-01-01 01:00');
 select *, row_start, row_end from t for system_time all;
+--echo # normal INSERT
 insert into t (a) values (4);
 select * from t;
+--echo # normal UPDATE
 update t set a= 5;
-select *, check_row(row_start, row_end) from t for system_time all where a >= 4;
+select *, check_row(row_start, row_end) from t for system_time all order by a;
 
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -159,7 +159,7 @@ set system_versioning_modify_history= on;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
 eval create or replace table t (
-  a int,
+  a int primary key,
   row_start $sys_datatype_expl as row start invisible,
   row_end $sys_datatype_expl as row end invisible,
   period for system_time (row_start, row_end)
@@ -168,13 +168,14 @@ eval create or replace table t (
 insert into t values (1);
 update t set a= 2;
 
---echo ## UPDATE of current row
-update t set row_start= @s1, row_end= @e1 where a= 2;
 --echo ## UPDATE of historical row
-update t set row_start= @s2, row_end= @e2 where a= 1;
+update t set row_start= @s1, row_end= @e1 where a= 1;
+--echo ## UPDATE of current row
+update t set row_start= @s2, row_end= @e2 where a= 2;
 --echo ## INSERT historical row
 insert into t (a, row_start, row_end) values (3, @s3, @e3);
 --echo ## normal INSERT
+# TODO: implement DEFAULT values for row_start, row_end
 insert into t (a) values (4);
 select * from t;
 --echo ## normal UPDATE
@@ -188,6 +189,11 @@ select *, check_row(row_start, row_end) from t2 for system_time all order by a;
 update t, t2 set t.row_start= @s1, t2.row_start= @s1, t.row_end= @s1, t2.row_end= @s1 where t.a > 3 and t2.a > 3;
 select *, check_row(row_start, row_end) from t for system_time all order by a;
 select *, check_row(row_start, row_end) from t2 for system_time all order by a;
+--echo ## REPLACE
+select *, row_start, row_end from t for system_time all;
+replace t (a, row_start, row_end) values (1, @s3, @e1), (2, @e2, @e2);
+select *, check_row(row_start, row_end) from t for system_time all order by a;
+select *, row_start, row_end from t for system_time all;
 
 --echo ## Honor secure_timestamp option
 --let $restart_parameters= --secure-timestamp=YES --system-versioning-modify-history=on

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -6232,7 +6232,7 @@ bool Item_field::fix_fields(THD *thd, Item **reference)
     else if (!from_field)
       goto error;
 
-    if (from_field->vers_sys_field() && thd->variables.vers_modify_history)
+    if (from_field->vers_sys_field() && thd->vers_modify_history())
     {
       DBUG_ASSERT(from_field->table);
       DBUG_ASSERT(from_field->table->versioned());

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -6232,6 +6232,12 @@ bool Item_field::fix_fields(THD *thd, Item **reference)
     else if (!from_field)
       goto error;
 
+    if (from_field->vers_sys_field() && thd->variables.vers_modify_history)
+    {
+      DBUG_ASSERT(from_field->table);
+      DBUG_ASSERT(from_field->table->versioned());
+      from_field->table->vers_write= false;
+    }
     table_list= (cached_table ? cached_table :
                  from_field != view_ref_found ?
                  from_field->table->pos_in_table_list : 0);

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -6232,7 +6232,8 @@ bool Item_field::fix_fields(THD *thd, Item **reference)
     else if (!from_field)
       goto error;
 
-    if (from_field->vers_sys_field() && thd->vers_modify_history())
+    if (from_field != view_ref_found &&
+        from_field->vers_sys_field() && thd->vers_modify_history())
     {
       DBUG_ASSERT(from_field->table);
       DBUG_ASSERT(from_field->table->versioned());

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7923,3 +7923,6 @@ ER_KEY_DOESNT_SUPPORT
 
 ER_TRUNCATE_ILLEGAL_VERS
         eng "Cannot truncate a versioned table"
+
+WARN_VERS_MODIFY_HISTORY
+        eng "Modifying history is prohibited, set `secure_timestamp` to NO or SUPER"

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8191,8 +8191,6 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
       table->auto_increment_field_not_null= TRUE;
     Item::Type type= value->type();
     bool vers_sys_field= table->versioned() && rfield->vers_sys_field();
-    if (vers_sys_field && thd->variables.vers_modify_history)
-      table->vers_write= false;
     if ((rfield->vcol_info || (vers_sys_field &&
                                !thd->variables.vers_modify_history)) &&
         type != Item::DEFAULT_VALUE_ITEM &&
@@ -8475,8 +8473,6 @@ fill_record(THD *thd, TABLE *table, Field **ptr, List<Item> &values,
       value=v++;
 
     bool vers_sys_field= table->versioned() && field->vers_sys_field();
-    if (vers_sys_field && thd->variables.vers_modify_history)
-      table->vers_write= false;
 
     if (field->field_index == autoinc_index)
       table->auto_increment_field_not_null= TRUE;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5708,7 +5708,8 @@ find_field_in_table(THD *thd, TABLE *table, const char *name, size_t length,
 
     if (field->invisible == INVISIBLE_SYSTEM &&
         thd->column_usage != MARK_COLUMNS_READ &&
-        thd->column_usage != COLUMNS_READ)
+        thd->column_usage != COLUMNS_READ &&
+        !thd->variables.vers_modify_history)
       DBUG_RETURN((Field*)0);
   }
   else
@@ -8187,7 +8188,8 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
       table->auto_increment_field_not_null= TRUE;
     Item::Type type= value->type();
     bool vers_sys_field= table->versioned() && rfield->vers_sys_field();
-    if ((rfield->vcol_info || vers_sys_field) &&
+    if ((rfield->vcol_info || (vers_sys_field &&
+                               !thd->variables.vers_modify_history)) &&
         type != Item::DEFAULT_VALUE_ITEM &&
         type != Item::NULL_ITEM &&
         table->s->table_category != TABLE_CATEGORY_TEMPORARY)

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8160,7 +8160,6 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
   Field *rfield;
   TABLE *table;
   bool only_unvers_fields= update && table_arg->versioned();
-  bool vers_mod_history= false;
   bool save_abort_on_warning= thd->abort_on_warning;
   bool save_no_errors= thd->no_errors;
   DBUG_ENTER("fill_record");
@@ -8190,8 +8189,9 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
     Item::Type type= value->type();
     bool vers_sys_field= table->versioned() && rfield->vers_sys_field();
     if (vers_sys_field && thd->variables.vers_modify_history)
-      vers_mod_history= true;
-    if ((rfield->vcol_info || (vers_sys_field && !vers_mod_history)) &&
+      table->vers_write= false;
+    if ((rfield->vcol_info || (vers_sys_field &&
+                               !thd->variables.vers_modify_history)) &&
         type != Item::DEFAULT_VALUE_ITEM &&
         type != Item::NULL_ITEM &&
         table->s->table_category != TABLE_CATEGORY_TEMPORARY)
@@ -8248,7 +8248,7 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
   if (table_arg->vfield &&
       table_arg->update_virtual_fields(table_arg->file, VCOL_UPDATE_FOR_WRITE))
     goto err;
-  if (table_arg->versioned() && !only_unvers_fields && !vers_mod_history)
+  if (table_arg->versioned() && !only_unvers_fields)
     table_arg->vers_update_fields();
   thd->abort_on_warning= save_abort_on_warning;
   thd->no_errors=        save_no_errors;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5712,7 +5712,7 @@ find_field_in_table(THD *thd, TABLE *table, const char *name, size_t length,
     if (field->invisible == INVISIBLE_SYSTEM &&
         thd->column_usage != MARK_COLUMNS_READ &&
         thd->column_usage != COLUMNS_READ &&
-        !thd->variables.vers_modify_history)
+        !thd->vers_modify_history())
       DBUG_RETURN((Field*)0);
   }
   else
@@ -7810,8 +7810,7 @@ insert_fields(THD *thd, Name_resolution_context *context, const char *db_name,
         Field_iterator_natural_join).
         But view fields can never be invisible.
       */
-      if ((field= field_iterator.field()) &&
-          DBUG_EVALUATE_IF("sysvers_show", false, field->invisible != VISIBLE))
+      if ((field= field_iterator.field()) && field->invisible != VISIBLE)
         continue;
 
       Item *item;
@@ -8191,8 +8190,7 @@ fill_record(THD *thd, TABLE *table_arg, List<Item> &fields, List<Item> &values,
       table->auto_increment_field_not_null= TRUE;
     Item::Type type= value->type();
     bool vers_sys_field= table->versioned() && rfield->vers_sys_field();
-    if ((rfield->vcol_info || (vers_sys_field &&
-                               !thd->variables.vers_modify_history)) &&
+    if ((rfield->vcol_info || (vers_sys_field && !thd->vers_modify_history())) &&
         type != Item::DEFAULT_VALUE_ITEM &&
         type != Item::NULL_ITEM &&
         table->s->table_category != TABLE_CATEGORY_TEMPORARY)

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -7810,7 +7810,8 @@ insert_fields(THD *thd, Name_resolution_context *context, const char *db_name,
         Field_iterator_natural_join).
         But view fields can never be invisible.
       */
-      if ((field= field_iterator.field()) && field->invisible != VISIBLE)
+      if ((field= field_iterator.field()) &&
+          DBUG_EVALUATE_IF("sysvers_show", false, field->invisible != VISIBLE))
         continue;
 
       Item *item;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -1984,6 +1984,9 @@ retry_share:
   table_list->updatable= 1; // It is not derived table nor non-updatable VIEW
   table_list->table= table;
 
+  if (table->versioned())
+    table->vers_write= true;
+
 #ifdef WITH_PARTITION_STORAGE_ENGINE
   if (unlikely(table->part_info))
   {
@@ -8472,6 +8475,8 @@ fill_record(THD *thd, TABLE *table, Field **ptr, List<Item> &values,
       value=v++;
 
     bool vers_sys_field= table->versioned() && field->vers_sys_field();
+    if (vers_sys_field && thd->variables.vers_modify_history)
+      table->vers_write= false;
 
     if (field->field_index == autoinc_index)
       table->auto_increment_field_not_null= TRUE;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -732,9 +732,8 @@ THD::THD(my_thread_id id, bool is_wsrep_applier, bool skip_global_sys_var_lock)
    m_stmt_da(&main_da),
    tdc_hash_pins(0),
    xid_hash_pins(0),
-   m_tmp_tables_locked(false)
+   m_tmp_tables_locked(false),
 #ifdef WITH_WSREP
-  ,
    wsrep_applier(is_wsrep_applier),
    wsrep_applier_closing(false),
    wsrep_client_thread(false),
@@ -742,8 +741,9 @@ THD::THD(my_thread_id id, bool is_wsrep_applier, bool skip_global_sys_var_lock)
    wsrep_po_handle(WSREP_PO_INITIALIZER),
    wsrep_po_cnt(0),
    wsrep_apply_format(0),
-   wsrep_ignore_table(false)
+   wsrep_ignore_table(false),
 #endif
+   modify_history_warned(false)
 {
   ulong tmp;
   bzero(&variables, sizeof(variables));
@@ -3875,6 +3875,7 @@ void THD::end_statement()
   lex_end(lex);
   delete lex->result;
   lex->result= 0;
+  modify_history_warned= false;
   /* Note that free_list is freed in cleanup_after_query() */
 
   /*
@@ -7121,6 +7122,34 @@ static bool protect_against_unsafe_warning_flood(int unsafe_type)
     }
   }
   DBUG_RETURN(unsafe_warning_suppression_active[unsafe_type]);
+}
+
+bool THD::vers_modify_history()
+{
+  if (!variables.vers_modify_history)
+    return false;
+  enum_sql_command c= lex->sql_command;
+  if (c != SQLCOM_UPDATE && c != SQLCOM_INSERT && c != SQLCOM_INSERT_SELECT)
+    return false;
+  if (opt_secure_timestamp >= SECTIME_REPL)
+  {
+    if (!modify_history_warned)
+    {
+      push_warning_printf(this, Sql_condition::WARN_LEVEL_WARN,
+                          WARN_VERS_MODIFY_HISTORY,
+                          ER_THD(this, WARN_VERS_MODIFY_HISTORY));
+      modify_history_warned= true;
+    }
+    return false;
+  }
+  if (opt_secure_timestamp == SECTIME_SUPER &&
+      !(security_ctx->master_access & SUPER_ACL))
+  {
+    my_error(ER_SPECIFIC_ACCESS_DENIED_ERROR, MYF(0), "SUPER");
+    return false;
+  }
+  return true;
+
 }
 
 MYSQL_TIME THD::query_start_TIME()

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -7130,7 +7130,7 @@ bool THD::vers_modify_history()
     return false;
   enum_sql_command c= lex->sql_command;
   if (c != SQLCOM_UPDATE && c != SQLCOM_INSERT && c != SQLCOM_INSERT_SELECT &&
-      c != SQLCOM_UPDATE_MULTI)
+      c != SQLCOM_UPDATE_MULTI && c != SQLCOM_REPLACE)
     return false;
   if (opt_secure_timestamp >= SECTIME_REPL)
   {

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -7129,7 +7129,8 @@ bool THD::vers_modify_history()
   if (!variables.vers_modify_history)
     return false;
   enum_sql_command c= lex->sql_command;
-  if (c != SQLCOM_UPDATE && c != SQLCOM_INSERT && c != SQLCOM_INSERT_SELECT)
+  if (c != SQLCOM_UPDATE && c != SQLCOM_INSERT && c != SQLCOM_INSERT_SELECT &&
+      c != SQLCOM_UPDATE_MULTI)
     return false;
   if (opt_secure_timestamp >= SECTIME_REPL)
   {

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4813,6 +4813,11 @@ public:
                                LOG_SLOW_DISABLE_ADMIN);
     query_plan_flags|= QPLAN_ADMIN;
   }
+
+  bool vers_modify_history() const
+  {
+    return variables.vers_modify_history;
+  }
 };
 
 inline void add_to_active_threads(THD *thd)

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -729,6 +729,7 @@ typedef struct system_variables
 
   vers_asof_timestamp_t vers_asof_timestamp;
   ulong vers_alter_history;
+  my_bool vers_modify_history;
 } SV;
 
 /**

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4814,10 +4814,8 @@ public:
     query_plan_flags|= QPLAN_ADMIN;
   }
 
-  bool vers_modify_history() const
-  {
-    return variables.vers_modify_history;
-  }
+  bool modify_history_warned;
+  bool vers_modify_history();
 };
 
 inline void add_to_active_threads(THD *thd)

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1932,7 +1932,7 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
             !table->file->referenced_by_foreign_key() &&
             (!table->triggers || !table->triggers->has_delete_triggers()))
         {
-          if (table->versioned(VERS_TRX_ID))
+          if (table->versioned(VERS_TRX_ID) && table->vers_write)
           {
             bitmap_set_bit(table->write_set, table->vers_start_field()->field_index);
             table->vers_start_field()->store(0, false);
@@ -1944,7 +1944,7 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
           if (likely(!error))
           {
             info->deleted++;
-            if (table->versioned(VERS_TIMESTAMP))
+            if (table->versioned(VERS_TIMESTAMP) && table->vers_write)
             {
               store_record(table, record[2]);
               error= vers_insert_history_row(table);

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1634,6 +1634,9 @@ static int last_uniq_key(TABLE *table,uint keynr)
 int vers_insert_history_row(TABLE *table)
 {
   DBUG_ASSERT(table->versioned(VERS_TIMESTAMP));
+  if (!table->vers_write)
+    return 0;
+
   restore_record(table,record[1]);
 
   // Set Sys_end to now()

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -3842,7 +3842,6 @@ int select_insert::send_data(List<Item> &values)
     DBUG_RETURN(1);
   }
 
-  table->vers_write= table->versioned();
   if (table_list)                               // Not CREATE ... SELECT
   {
     switch (table_list->view_check_option(thd, info.ignore)) {
@@ -3854,7 +3853,6 @@ int select_insert::send_data(List<Item> &values)
   }
 
   error= write_record(thd, table, &info);
-  table->vers_write= table->versioned();
   table->auto_increment_field_not_null= FALSE;
   
   if (likely(!error))

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -742,7 +742,7 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
   {
     for (table= tables; table; table= table->next_local)
     {
-      if (table->table && table->table->versioned())
+      if (table->table && table->table->versioned() && table->table->vers_write)
         versioned_tables++;
       else if (table->vers_conditions.is_set() &&
               (table->is_non_derived() || !table->vers_conditions.used))

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1101,7 +1101,7 @@ update_end:
   if (likely(error < 0) && likely(!thd->lex->analyze_stmt))
   {
     char buff[MYSQL_ERRMSG_SIZE];
-    if (!table->versioned(VERS_TIMESTAMP))
+    if (!table->versioned(VERS_TIMESTAMP) || !table->vers_write)
       my_snprintf(buff, sizeof(buff), ER_THD(thd, ER_UPDATE_INFO), (ulong) found,
                   (ulong) updated,
                   (ulong) thd->get_stmt_da()->current_statement_warn_count());

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -794,7 +794,7 @@ update_begin:
   THD_STAGE_INFO(thd, stage_updating);
   while (!(error=info.read_record()) && !thd->killed)
   {
-    if (table->versioned() && !table->vers_end_field()->is_max())
+    if (table->vers_write && !table->vers_end_field()->is_max())
     {
       continue;
     }
@@ -2324,7 +2324,7 @@ int multi_update::send_data(List<Item> &not_used_values)
     if (table->status & (STATUS_NULL_ROW | STATUS_UPDATED))
       continue;
 
-    if (table->versioned() && !table->vers_end_field()->is_max())
+    if (table->vers_write && !table->vers_end_field()->is_max())
     {
       continue;
     }

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -398,11 +398,15 @@ static Sys_var_vers_asof Sys_vers_asof_timestamp(
 
 static const char *vers_alter_history_keywords[]= {"ERROR", "KEEP", NullS};
 static Sys_var_enum Sys_vers_alter_history(
-       "system_versioning_alter_history", "Versioning ALTER TABLE mode. "
+       "system_versioning_alter_history", "System Versioning ALTER TABLE mode. "
        "ERROR: Fail ALTER with error; " /* TODO: fail only when history non-empty */
        "KEEP: Keep historical system rows and subject them to ALTER",
        SESSION_VAR(vers_alter_history), CMD_LINE(REQUIRED_ARG),
        vers_alter_history_keywords, DEFAULT(VERS_ALTER_HISTORY_ERROR));
+
+static Sys_var_mybool Sys_vers_modify_history(
+       "system_versioning_modify_history", "Allow history modification by DML",
+       SESSION_VAR(vers_modify_history), CMD_LINE(OPT_ARG), DEFAULT(FALSE));
 
 static Sys_var_ulonglong Sys_binlog_cache_size(
        "binlog_cache_size", "The size of the transactional cache for "

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -398,7 +398,7 @@ static Sys_var_vers_asof Sys_vers_asof_timestamp(
 
 static const char *vers_alter_history_keywords[]= {"ERROR", "KEEP", NullS};
 static Sys_var_enum Sys_vers_alter_history(
-       "system_versioning_alter_history", "System Versioning ALTER TABLE mode. "
+       "system_versioning_alter_history", "Versioning ALTER TABLE mode. "
        "ERROR: Fail ALTER with error; " /* TODO: fail only when history non-empty */
        "KEEP: Keep historical system rows and subject them to ALTER",
        SESSION_VAR(vers_alter_history), CMD_LINE(REQUIRED_ARG),

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -7710,19 +7710,15 @@ void TABLE::vers_update_fields()
   bitmap_set_bit(write_set, vers_start_field()->field_index);
   bitmap_set_bit(write_set, vers_end_field()->field_index);
 
+  if (!vers_write)
+    return;
+
   if (versioned(VERS_TIMESTAMP))
   {
-    if (!vers_write)
-      return;
     if (vers_start_field()->store_timestamp(in_use->query_start(),
                                             in_use->query_start_sec_part()))
       DBUG_ASSERT(0);
     bitmap_set_bit(read_set, vers_start_field()->field_index);
-  }
-  else
-  {
-    if (!vers_write)
-      return;
   }
 
   vers_end_field()->set_max();


### PR DESCRIPTION
1. Add server variable system_versioning_modify_history which will allow to set values for row_start, row_end in DML operations.
2. If secure_timestamp is YES or REPLICATION, system_versioning_modify_history does not have effect. If secure_timestamp is SUPER, system_versioning_modify_history requires special privilege (same as for setting current timestamp).
