### PR TITLE
 MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables

### DIFF
--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -181,6 +181,17 @@ select *, check_row(row_start, row_end) from t1 for system_time all;
 x	check_row(row_start, row_end)
 2	CURRENT ROW
 1	HISTORICAL ROW
+# MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables
+set @old_row_image= @@binlog_row_image;
+set binlog_row_image= minimal;
+create or replace table t1 (pk int, i int, primary key(pk))
+with system versioning;
+insert into t1 values (1,10),(2,20);
+update t1 set i = 0;
+connection slave;
+connection master;
+drop table t1;
+set binlog_row_image= @old_row_image;
 drop database test;
 create database test;
 include/rpl_end.inc

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -153,6 +153,20 @@ drop table t1;
 --exec $MYSQL_BINLOG -v $datadir/$binlog_file | $MYSQL test
 select *, check_row(row_start, row_end) from t1 for system_time all;
 
+--echo # MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables
+set @old_row_image= @@binlog_row_image;
+set binlog_row_image= minimal;
+
+create or replace table t1 (pk int, i int, primary key(pk))
+with system versioning;
+insert into t1 values (1,10),(2,20);
+update t1 set i = 0;
+
+--sync_slave_with_master
+--connection master
+drop table t1;
+set binlog_row_image= @old_row_image;
+
 drop database test;
 create database test;
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -891,6 +891,7 @@ update_begin:
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
+              table->mark_columns_per_binlog_row_image();
               error= vers_insert_history_row(table);
               restore_record(table, record[2]);
             }


### PR DESCRIPTION
* mark columns for binlog before inserting history row