### PR TITLE
MDEV-15990: REPLACE on a precise-versioned table returns duplicate key error (ER_DUP_ENTRY)

### DIFF
--- a/mysql-test/suite/versioning/r/optimized.result
+++ b/mysql-test/suite/versioning/r/optimized.result
@@ -71,11 +71,15 @@ period for system_time(row_start, row_end)
 ) with system versioning;
 insert t values (1, 2);
 replace t values (1, 3);
-select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
 from t for system_time all order by x;
-id	x	current	start_nonzero
-1	2	0	1
-1	3	1	1
+id	x	check_row(row_start, row_end)	start_nonzero
+1	2	HISTORICAL ROW	1
+1	3	CURRENT ROW	1
+# ensure that row_start is not duplicated
+select count(row_start) as empty from t for system_time all
+group by row_start having count(row_start) > 1;
+empty
 drop table t;
 create or replace table t (x int with system versioning, y int);
 select column_name, extra from information_schema.columns where table_name='t';

--- a/mysql-test/suite/versioning/r/optimized.result
+++ b/mysql-test/suite/versioning/r/optimized.result
@@ -61,6 +61,22 @@ a	b
 3	4
 select * from t for system_time as of timestamp now(6) where b is NULL;
 a	b
+# Replace on unversioned field should create history record
+create or replace table t(
+id int primary key,
+x int without system versioning,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time(row_start, row_end)
+) with system versioning;
+insert t values (1, 2);
+replace t values (1, 3);
+select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+from t for system_time all order by x;
+id	x	current	start_nonzero
+1	2	0	1
+1	3	1	1
+drop table t;
 create or replace table t (x int with system versioning, y int);
 select column_name, extra from information_schema.columns where table_name='t';
 column_name	extra
@@ -71,5 +87,6 @@ Table	Create Table
 t	CREATE TABLE `t` (
   `x` int(11) DEFAULT NULL,
   `y` int(11) DEFAULT NULL WITHOUT SYSTEM VERSIONING
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
-drop table t;
+) ENGINE=DEFAULT_ENGINE DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+drop database test;
+create database test;

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -12,13 +12,23 @@ replace t values (1, 3);
 # MDEV-15990: REPLACE on a precise-versioned table
 # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
+create table log(s varchar(3));
+create trigger tr1del before delete on t
+for each row insert into log values('DEL');
+replace t values (1, 4), (1, 40), (1, 400);
 select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
 from t for system_time all order by x, row_end;
 id	x	check_row(row_start, row_end)	start_nonzero
 1	2	HISTORICAL ROW	1
 1	3	HISTORICAL ROW	1
 1	3	HISTORICAL ROW	1
-1	40	CURRENT ROW	1
+1	40	HISTORICAL ROW	1
+1	400	CURRENT ROW	1
+select * from log;
+s
+DEL
+DEL
+DEL
 # ensure that row_start is not duplicated
 select count(row_start) as empty from t for system_time all
 group by row_start having count(row_start) > 1;

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -27,28 +27,6 @@ id	x	current	start_nonzero
 1	3	0	1
 1	3	0	1
 1	40	1	1
-select count(row_start) as empty from t for system_time all
-group by row_start having count(row_start) > 1;
-empty
-drop table t;
-# replace on unversioned field shoud create history record
-create or replace table t(
-id int,
-KEY_TYPE(id),
-x int without system versioning,
-row_start SYS_DATATYPE as row start invisible,
-row_end SYS_DATATYPE as row end invisible,
-period for system_time(row_start, row_end)
-) with system versioning;
-insert t values (1, 2);
-replace t values (1, 3);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-row_start != 0 as start_nonzero
-from t for system_time all
-group by row_start order by x, row_end;
-id	x	current	unique_start	start_nonzero
-1	2	0	1	1
-1	3	1	1	1
 drop table t;
 create table t (
 id int unique,

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -27,8 +27,8 @@ id	x	current	start_nonzero
 1	3	0	1
 1	3	0	1
 1	40	1	1
-select count(row_start) != 1 as empty from t for system_time all
-group by row_start having empty = 1;
+select count(row_start) as empty from t for system_time all
+group by row_start having count(row_start) > 1;
 empty
 drop table t;
 # replace on unversioned field shoud create history record

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -9,24 +9,20 @@ period for system_time(row_start, row_end)
 insert t values (1, 2);
 replace t values (1, 3);
 replace t values (1, 3);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-row_start != 0 as start_nonzero
-from t for system_time all
-group by row_start order by x, row_end;
-id	x	current	unique_start	start_nonzero
-1	2	0	1	1
-1	3	0	1	1
-1	3	1	1	1
 # MDEV-15990: REPLACE on a precise-versioned table
 # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
-select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
 from t for system_time all order by x, row_end;
-id	x	current	start_nonzero
-1	2	0	1
-1	3	0	1
-1	3	0	1
-1	40	1	1
+id	x	check_row(row_start, row_end)	start_nonzero
+1	2	HISTORICAL ROW	1
+1	3	HISTORICAL ROW	1
+1	3	HISTORICAL ROW	1
+1	40	CURRENT ROW	1
+# ensure that row_start is not duplicated
+select count(row_start) as empty from t for system_time all
+group by row_start having count(row_start) > 1;
+empty
 drop table t;
 create table t (
 id int unique,

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -8,10 +8,46 @@ period for system_time(row_start, row_end)
 ) with system versioning;
 insert t values (1, 2);
 replace t values (1, 3);
-select *, current_row(row_end) as current from t for system_time all order by x;
-id	x	current
-1	2	0
-1	3	1
+replace t values (1, 3);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+row_start != 0 as start_nonzero
+from t for system_time all
+group by row_start order by x, row_end;
+id	x	current	unique_start	start_nonzero
+1	2	0	1	1
+1	3	0	1	1
+1	3	1	1	1
+# MDEV-15990: REPLACE on a precise-versioned table
+# returns duplicate key error (ER_DUP_ENTRY)
+replace t values (1, 3), (1, 30), (1, 40);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+row_start != 0 as start_nonzero
+from t for system_time all
+group by row_start order by x, row_end;
+id	x	current	unique_start	start_nonzero
+1	2	0	1	1
+1	3	0	1	1
+1	3	0	1	1
+1	40	1	1	1
+drop table t;
+# replace on unversioned field shoud create history record
+create or replace table t(
+id int,
+KEY_TYPE(id),
+x int without system versioning,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time(row_start, row_end)
+) with system versioning;
+insert t values (1, 2);
+replace t values (1, 3);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+row_start != 0 as start_nonzero
+from t for system_time all
+group by row_start order by x, row_end;
+id	x	current	unique_start	start_nonzero
+1	2	0	1	1
+1	3	1	1	1
 drop table t;
 create table t (
 id int unique,

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -20,15 +20,16 @@ id	x	current	unique_start	start_nonzero
 # MDEV-15990: REPLACE on a precise-versioned table
 # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-row_start != 0 as start_nonzero
-from t for system_time all
-group by row_start order by x, row_end;
-id	x	current	unique_start	start_nonzero
-1	2	0	1	1
-1	3	0	1	1
-1	3	0	1	1
-1	40	1	1	1
+select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+from t for system_time all order by x, row_end;
+id	x	current	start_nonzero
+1	2	0	1
+1	3	0	1
+1	3	0	1
+1	40	1	1
+select count(row_start) != 1 as empty from t for system_time all
+group by row_start having empty = 1;
+empty
 drop table t;
 # replace on unversioned field shoud create history record
 create or replace table t(

--- a/mysql-test/suite/versioning/t/optimized.test
+++ b/mysql-test/suite/versioning/t/optimized.test
@@ -1,3 +1,6 @@
+--source suite/versioning/common.inc
+--source suite/versioning/engines.inc
+
 create table t (
   a int,
   b int without system versioning
@@ -30,11 +33,29 @@ insert into t values (1, 2), (3, 4);
 select * from t for system_time as of timestamp now(6);
 select * from t for system_time as of timestamp now(6) where b is NULL;
 
+--echo # Replace on unversioned field should create history record
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval create or replace table t(
+  id int primary key,
+  x int without system versioning,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time(row_start, row_end)
+) with system versioning;
+
+insert t values (1, 2);
+replace t values (1, 3);
+select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+from t for system_time all order by x;
+drop table t;
+
 #
 # MDEV-15062 Information Schema COLUMNS Table does not show system versioning information
 #
 create or replace table t (x int with system versioning, y int);
 select column_name, extra from information_schema.columns where table_name='t';
+--replace_result $default_engine DEFAULT_ENGINE $sys_datatype_expl SYS_DATATYPE
 show create table t;
 
-drop table t;
+drop database test;
+create database test;

--- a/mysql-test/suite/versioning/t/optimized.test
+++ b/mysql-test/suite/versioning/t/optimized.test
@@ -45,8 +45,13 @@ eval create or replace table t(
 
 insert t values (1, 2);
 replace t values (1, 3);
-select *, current_row(row_end) as current, row_start != 0 as start_nonzero
-from t for system_time all order by x;
+select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
+  from t for system_time all order by x;
+
+--echo # ensure that row_start is not duplicated
+select count(row_start) as empty from t for system_time all
+  group by row_start having count(row_start) > 1;
+
 drop table t;
 
 #

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -23,10 +23,11 @@ select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
 --echo # MDEV-15990: REPLACE on a precise-versioned table
 --echo # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-    row_start != 0 as start_nonzero
-  from t for system_time all
-  group by row_start order by x, row_end;
+select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+  from t for system_time all order by x, row_end;
+
+select count(row_start) != 1 as empty from t for system_time all
+  group by row_start having empty = 1;
 drop table t;
 
 --echo # replace on unversioned field shoud create history record

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -14,7 +14,38 @@ eval create or replace table t(
 
 insert t values (1, 2);
 replace t values (1, 3);
-select *, current_row(row_end) as current from t for system_time all order by x;
+replace t values (1, 3);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+    row_start != 0 as start_nonzero
+  from t for system_time all
+  group by row_start order by x, row_end;
+
+--echo # MDEV-15990: REPLACE on a precise-versioned table
+--echo # returns duplicate key error (ER_DUP_ENTRY)
+replace t values (1, 3), (1, 30), (1, 40);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+    row_start != 0 as start_nonzero
+  from t for system_time all
+  group by row_start order by x, row_end;
+drop table t;
+
+--echo # replace on unversioned field shoud create history record
+--replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
+eval create or replace table t(
+  id int,
+  $KEY_TYPE(id),
+  x int without system versioning,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time(row_start, row_end)
+) with system versioning;
+
+insert t values (1, 2);
+replace t values (1, 3);
+select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
+    row_start != 0 as start_nonzero
+  from t for system_time all
+  group by row_start order by x, row_end;
 drop table t;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -19,8 +19,15 @@ replace t values (1, 3);
 --echo # MDEV-15990: REPLACE on a precise-versioned table
 --echo # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
+
+create table log(s varchar(3));
+create trigger tr1del before delete on t
+  for each row insert into log values('DEL');
+replace t values (1, 4), (1, 40), (1, 400);
+
 select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
   from t for system_time all order by x, row_end;
+select * from log;
 
 --echo # ensure that row_start is not duplicated
 select count(row_start) as empty from t for system_time all

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -15,16 +15,16 @@ eval create or replace table t(
 insert t values (1, 2);
 replace t values (1, 3);
 replace t values (1, 3);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-    row_start != 0 as start_nonzero
-  from t for system_time all
-  group by row_start order by x, row_end;
 
 --echo # MDEV-15990: REPLACE on a precise-versioned table
 --echo # returns duplicate key error (ER_DUP_ENTRY)
 replace t values (1, 3), (1, 30), (1, 40);
-select *, current_row(row_end) as current, row_start != 0 as start_nonzero
+select *, check_row(row_start, row_end), row_start != 0 as start_nonzero
   from t for system_time all order by x, row_end;
+
+--echo # ensure that row_start is not duplicated
+select count(row_start) as empty from t for system_time all
+  group by row_start having count(row_start) > 1;
 
 drop table t;
 

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -26,8 +26,8 @@ replace t values (1, 3), (1, 30), (1, 40);
 select *, current_row(row_end) as current, row_start != 0 as start_nonzero
   from t for system_time all order by x, row_end;
 
-select count(row_start) != 1 as empty from t for system_time all
-  group by row_start having empty = 1;
+select count(row_start) as empty from t for system_time all
+  group by row_start having count(row_start) > 1;
 drop table t;
 
 --echo # replace on unversioned field shoud create history record

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -26,27 +26,6 @@ replace t values (1, 3), (1, 30), (1, 40);
 select *, current_row(row_end) as current, row_start != 0 as start_nonzero
   from t for system_time all order by x, row_end;
 
-select count(row_start) as empty from t for system_time all
-  group by row_start having count(row_start) > 1;
-drop table t;
-
---echo # replace on unversioned field shoud create history record
---replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
-eval create or replace table t(
-  id int,
-  $KEY_TYPE(id),
-  x int without system versioning,
-  row_start $sys_datatype_expl as row start invisible,
-  row_end $sys_datatype_expl as row end invisible,
-  period for system_time(row_start, row_end)
-) with system versioning;
-
-insert t values (1, 2);
-replace t values (1, 3);
-select *, current_row(row_end) as current, count(row_start) = 1 as unique_start,
-    row_start != 0 as start_nonzero
-  from t for system_time all
-  group by row_start order by x, row_end;
 drop table t;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1934,7 +1934,6 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
         {
           if (table->versioned(VERS_TRX_ID) && table->vers_write)
           {
-            bitmap_set_bit(table->write_set, table->vers_start_field()->field_index);
             table->vers_start_field()->store(0, false);
           }
           if (unlikely(error= table->file->ha_update_row(table->record[1],

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1934,6 +1934,7 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
         {
           if (table->versioned(VERS_TRX_ID) && table->vers_write)
           {
+            bitmap_set_bit(table->write_set, table->vers_start_field()->field_index);
             table->vers_start_field()->store(0, false);
           }
           if (unlikely(error= table->file->ha_update_row(table->record[1],

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8840,15 +8840,15 @@ ha_innobase::update_row(
 	                   && table->vers_start_id() == 0;
 
 	if (force_insert) {
-	  table->vers_start_field()->store(trx->id);
+		table->vers_start_field()->store(trx->id);
 
-	  ptrdiff_t offset= table->vers_start_field()->ptr - table->record[0];
-    longlong a= sint8korr(table->record[0] + offset);
-    longlong b= sint8korr(table->record[1] + offset);
+		Field *start= table->vers_start_field();
+		longlong old_val= uint8korr(start->ptr_in_record(old_row));
+		longlong new_val= uint8korr(start->ptr_in_record(new_row));
 
-    /* do not do versioned insert twice on the same transaction and same row */
-    force_insert= (a != b);
-  }
+		/* do not do versioned insert twice on the same transaction and same row */
+		force_insert= (old_val != new_val);
+	}
 
 	/* Build an update vector from the modified fields in the rows
 	(uses m_upd_buf of the handle) */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8836,6 +8836,20 @@ ha_innobase::update_row(
 	upd_t*		uvect = row_get_prebuilt_update_vector(m_prebuilt);
 	ib_uint64_t	autoinc;
 
+	bool force_insert= table->versioned_write(VERS_TRX_ID)
+	                   && table->vers_start_id() == 0;
+
+	if (force_insert) {
+	  table->vers_start_field()->store(trx->id);
+
+	  ptrdiff_t offset= table->vers_start_field()->ptr - table->record[0];
+    longlong a= sint8korr(table->record[0] + offset);
+    longlong b= sint8korr(table->record[1] + offset);
+
+    /* do not do versioned insert twice on the same transaction and same row */
+    force_insert= (a != b);
+  }
+
 	/* Build an update vector from the modified fields in the rows
 	(uses m_upd_buf of the handle) */
 
@@ -8855,7 +8869,7 @@ ha_innobase::update_row(
 		DBUG_RETURN(HA_ERR_RECORD_IS_THE_SAME);
 	} else {
 		const bool vers_set_fields = m_prebuilt->versioned_write
-			&& m_prebuilt->upd_node->update->affects_versioned();
+			&& (m_prebuilt->upd_node->update->affects_versioned() || force_insert);
 		const bool vers_ins_row = vers_set_fields
 			&& thd_sql_command(m_user_thd) != SQLCOM_ALTER_TABLE;
 
@@ -8874,7 +8888,8 @@ ha_innobase::update_row(
 		if (error == DB_SUCCESS && vers_ins_row
 		    /* Multiple UPDATE of same rows in single transaction create
 		       historical rows only once. */
-		    && trx->id != table->vers_start_id()) {
+		    && (trx->id != table->vers_start_id() || force_insert)
+		    && trx->id != table->vers_end_id()){
 			error = row_insert_for_mysql((byte*) old_row,
 						     m_prebuilt,
 						     ROW_INS_HISTORICAL);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8843,11 +8843,10 @@ ha_innobase::update_row(
 		table->vers_start_field()->store(trx->id);
 
 		Field *start= table->vers_start_field();
-		longlong old_val= uint8korr(start->ptr_in_record(old_row));
-		longlong new_val= uint8korr(start->ptr_in_record(new_row));
+		trx_id_t old_trx_id= uint8korr(start->ptr_in_record(old_row));
 
-		/* do not do versioned insert twice on the same transaction and same row */
-		force_insert= (old_val != new_val);
+		/* avoid double versioned insert on the same transaction and same row */
+		force_insert= (old_trx_id != trx->id);
 	}
 
 	/* Build an update vector from the modified fields in the rows


### PR DESCRIPTION
* handle zero value in `row_start` `trx_id`
* refuse to do more than one versioned insert on the same transaction and same row