### PR TITLE
MDEV-16764: Crash on delete from sql-versioned table with update trigger

### DIFF
--- a/mysql-test/suite/versioning/r/delete.result
+++ b/mysql-test/suite/versioning/r/delete.result
@@ -42,6 +42,20 @@ XNo_vt1
 2
 4
 5
+# MDEV-16764 Crash on delete from sql-versioned table with update trigger
+create or replace table log_tbl(log varchar(4));
+create or replace procedure log(s varchar(4)) insert into log_tbl values(s);
+create trigger tr2upd before update on t1 for each row call log('>UPD');
+create trigger tr1upd after  update on t1 for each row call log('<UPD');
+create trigger tr2del before delete on t1 for each row call log('>DEL');
+create trigger tr1del after  delete on t1 for each row call log('<DEL');
+delete from t1 where XNo = 4;
+select * from log_tbl;
+log
+>DEL
+<DEL
+drop procedure log;
+drop table log_tbl;
 drop view vt1;
 drop table t1;
 create or replace table t1(

--- a/mysql-test/suite/versioning/t/delete.test
+++ b/mysql-test/suite/versioning/t/delete.test
@@ -28,6 +28,20 @@ create view vt1 as select XNo from t1;
 select XNo as XNo_vt1 from vt1;
 delete from vt1 where XNo = 3;
 select XNo as XNo_vt1 from vt1;
+
+--echo # MDEV-16764 Crash on delete from sql-versioned table with update trigger
+create or replace table log_tbl(log varchar(4));
+create or replace procedure log(s varchar(4)) insert into log_tbl values(s);
+create trigger tr2upd before update on t1 for each row call log('>UPD');
+create trigger tr1upd after  update on t1 for each row call log('<UPD');
+create trigger tr2del before delete on t1 for each row call log('>DEL');
+create trigger tr1del after  delete on t1 for each row call log('<DEL');
+
+delete from t1 where XNo = 4;
+select * from log_tbl;
+
+drop procedure log;
+drop table log_tbl;
 drop view vt1;
 drop table t1;
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8376,8 +8376,10 @@ fill_record_n_invoke_before_triggers(THD *thd, TABLE *table,
   int result;
   Table_triggers_list *triggers= table->triggers;
 
-  result= fill_record(thd, table, fields, values, ignore_errors,
-                      event == TRG_EVENT_UPDATE);
+  bool update= event == TRG_EVENT_UPDATE ||
+               (event == TRG_EVENT_DELETE && table->versioned(VERS_TIMESTAMP));
+
+  result= fill_record(thd, table, fields, values, ignore_errors, update);
 
   if (!result && triggers)
   {

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -527,7 +527,6 @@ int mysql_update_inner(THD *thd, TABLE_LIST *table_list, List<Item> &fields,
   has_triggers= (table->triggers &&
                  (table->triggers->has_triggers(event, TRG_ACTION_BEFORE) ||
                  table->triggers->has_triggers(event, TRG_ACTION_AFTER)));
-  sql_print_information(has_triggers?"has triggers": "no triggers");
   DBUG_PRINT("info", ("has_triggers: %s", has_triggers ? "TRUE" : "FALSE"));
   binlog_is_row= thd->is_current_stmt_binlog_format_row();
   DBUG_PRINT("info", ("binlog_is_row: %s", binlog_is_row ? "TRUE" : "FALSE"));

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -351,6 +351,7 @@ int mysql_update_inner(THD *thd, TABLE_LIST *table_list, List<Item> &fields,
   bool do_direct_update= false;
   SORT_INFO *file_sort= NULL;
   READ_RECORD info;
+  trg_event_type event;
   ha_rows updated= 0;
   ha_rows found= 0;
   bool transactional_table= table->file->has_transactions();
@@ -520,11 +521,13 @@ int mysql_update_inner(THD *thd, TABLE_LIST *table_list, List<Item> &fields,
   DBUG_EXECUTE_IF("show_explain_probe_update_exec_start", 
                   dbug_serve_apcs(thd, 1););
 
+  event= thd->lex->sql_command == SQLCOM_DELETE ? TRG_EVENT_DELETE
+                                                : TRG_EVENT_UPDATE;
+
   has_triggers= (table->triggers &&
-                 (table->triggers->has_triggers(TRG_EVENT_UPDATE,
-                                                TRG_ACTION_BEFORE) ||
-                 table->triggers->has_triggers(TRG_EVENT_UPDATE,
-                                               TRG_ACTION_AFTER)));
+                 (table->triggers->has_triggers(event, TRG_ACTION_BEFORE) ||
+                 table->triggers->has_triggers(event, TRG_ACTION_AFTER)));
+  sql_print_information(has_triggers?"has triggers": "no triggers");
   DBUG_PRINT("info", ("has_triggers: %s", has_triggers ? "TRUE" : "FALSE"));
   binlog_is_row= thd->is_current_stmt_binlog_format_row();
   DBUG_PRINT("info", ("binlog_is_row: %s", binlog_is_row ? "TRUE" : "FALSE"));
@@ -810,7 +813,7 @@ update_begin:
       store_record(table,record[1]);
 
       if (fill_record_n_invoke_before_triggers(thd, table, fields, values, 0,
-                                               TRG_EVENT_UPDATE))
+                                               event))
         break; /* purecov: inspected */
 
       found++;
@@ -922,7 +925,7 @@ update_begin:
       }
 
       if (table->triggers &&
-          unlikely(table->triggers->process_triggers(thd, TRG_EVENT_UPDATE,
+          unlikely(table->triggers->process_triggers(thd, event,
                                                      TRG_ACTION_AFTER, TRUE)))
       {
         error= 1;


### PR DESCRIPTION
* mysql_update_inner: use delete triggers for timestamp-versioned `DELETE`
* fill_record_n_invoke_before_triggers: respect timestamp-versioned `DELETE`

related to tempesta-tech/mariadb#517