### PR TITLE
MDEV-16023 Unfortunate error message WARN_VERS_PART_FULL (partition <…

### DIFF
--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -873,7 +873,6 @@ void partition_info::vers_set_hist_part(THD *thd)
       if (next->range_value > thd->query_start())
         return;
     }
-    goto warn;
   }
   return;
 warn:


### PR DESCRIPTION
…name> is full) when rotation time for the last interval passed

* remove one case of WARN_VERS_PART_FULL