### PR TITLE
MDEV-15951 system versioning by trx id doesn't work with partitioning

### DIFF
--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -1,6 +1,6 @@
 set system_versioning_alter_history=keep;
 # Check conventional partitioning on temporal tables
-create table t1 (x int)
+create or replace table t1 (x int, ROW_START, ROW_END, period for system_time(row_start, row_end))
 with system versioning
 partition by range columns (x) (
 partition p0 values less than (100),
@@ -34,7 +34,9 @@ select * from t1 partition (p1) for system_time all;
 x
 300
 # Engine change native <-> non-native versioning prohibited
-create or replace table t1 (i int) engine=DEFAULT_ENGINE with system versioning partition by hash(i);
+create or replace table t1 (i int, ROW_START, ROW_END, period for system_time(row_start, row_end))
+engine=DEFAULT_ENGINE
+with system versioning partition by hash(i);
 alter table t1 engine=NON_DEFAULT_ENGINE;
 ERROR HY000: Not allowed for system-versioned `test`.`t1`. Change to/from native system versioning engine is not supported.
 ## CREATE TABLE
@@ -320,14 +322,14 @@ select * from t1 partition (p1sp0);
 x
 select * from t1 partition (p1sp1);
 x
-create or replace table t1 (a bigint)
+create or replace table t1 (a bigint, ROW_START, ROW_END, period for system_time(row_start, row_end))
 with system versioning
 partition by range (a)
 (partition p0 values less than (20) engine innodb,
 partition p1 values less than maxvalue engine innodb);
 insert into t1 values (1);
 create or replace table t1 (
-f_int1 integer default 0
+f_int1 integer default 0, ROW_START, ROW_END, period for system_time(row_start, row_end)
 ) with system versioning
 partition by range(f_int1)
 subpartition by hash(f_int1)
@@ -336,7 +338,8 @@ subpartition by hash(f_int1)
 subpartition subpart12 storage engine = 'innodb'));
 insert into t1 values (1);
 create or replace table t1 (i int) engine=innodb partition by key(i);
-alter table t1 add system versioning;
+alter table t1 add column ROW_START, add column ROW_END, add period for system_time(row_start, row_end),
+add system versioning;
 insert into t1 values();
 # MDEV-14722 Assertion in ha_commit_trans for sub-statement
 create or replace table t1 (i int) with system versioning
@@ -507,6 +510,72 @@ Warning	1906	The value specified for generated column 'v' in table 't1' ignored
 create or replace table t1 (i int) with system versioning partition by system_time limit 10 (partition p0 history, partition pn current);
 select * from t1 partition (p0) for system_time all;
 ERROR HY000: SYSTEM_TIME partitions in table `t1` does not support historical query
+# MDEV-15951 system versioning by trx id doesn't work with partitioning
+# currently trx_id does not support partitioning by system_time
+create or replace table t1(
+i int,
+row_start bigint unsigned generated always as row start,
+row_end bigint unsigned generated always as row end,
+period for system_time(row_start, row_end)
+) engine=InnoDB with system versioning partition by system_time (
+partition p0 history,
+partition pn current
+);
+ERROR HY000: `row_start` must be of type TIMESTAMP(6) for system-versioned table `t1`
+create or replace table t1(
+i int,
+row_start bigint unsigned generated always as row start,
+row_end bigint unsigned generated always as row end,
+period for system_time(row_start, row_end)
+) engine=InnoDB with system versioning;
+alter table t1  partition by system_time (
+partition p0 history,
+partition pn current
+);
+ERROR HY000: `row_start` must be of type TIMESTAMP(6) for system-versioned table `t1`
+create or replace table t (
+a int primary key,
+row_start bigint unsigned as row start invisible,
+row_end bigint unsigned as row end invisible,
+period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by key() (
+partition p1,
+partition p2
+);
+ERROR HY000: Using ROW START/END for patitioning is not supported for transactional system-versioned tables
+create or replace table t (
+a int primary key,
+row_start bigint unsigned as row start invisible,
+row_end bigint unsigned as row end invisible,
+period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by key(a, row_start) (
+partition p1,
+partition p2
+);
+ERROR HY000: Using ROW START/END for patitioning is not supported for transactional system-versioned tables
+create or replace table t (
+a int primary key,
+row_start bigint unsigned as row start invisible,
+row_end bigint unsigned as row end invisible,
+period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by hash(a + row_end * 2) (
+partition p1,
+partition p2
+);
+ERROR HY000: Using ROW START/END for patitioning is not supported for transactional system-versioned tables
+create or replace table t (
+a int primary key,
+row_start bigint unsigned as row start invisible,
+row_end bigint unsigned as row end invisible,
+period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by range columns (a, row_start) (
+partition p1 values less than (100, 100)
+);
+ERROR HY000: Using ROW START/END for patitioning is not supported for transactional system-versioned tables
 # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/r/update.result
+++ b/mysql-test/suite/versioning/r/update.result
@@ -239,5 +239,20 @@ B1	salary
 select @tmp2 = sys_trx_start as B2, salary from t2;
 B2	salary
 1	2500
+#
+# MDEV-17089 Updating a System Versioned Table always causes a row to be updated,
+# regardless if the data is the same or not
+#
+create or replace table t1 (
+x int primary key,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 1;
+select * from t1 for system_time all;
+x
+1
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/versioning/t/partition.combinations
+++ b/mysql-test/suite/versioning/t/partition.combinations
@@ -1,5 +1,8 @@
 [timestamp]
 default-storage-engine=innodb
 
+[trx_id]
+default-storage-engine=innodb
+
 [myisam]
 default-storage-engine=myisam

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -1,10 +1,15 @@
 -- source include/have_partition.inc
 -- source suite/versioning/common.inc
 
+--let row_start= row_start $sys_datatype_expl as row start invisible
+--let row_end= row_end $sys_datatype_expl as row end invisible
+--let period= period for system_time(row_start, row_end)
+
 set system_versioning_alter_history=keep;
 --echo # Check conventional partitioning on temporal tables
 
-create table t1 (x int)
+--replace_result $row_start ROW_START $row_end ROW_END
+eval create or replace table t1 (x int, $row_start, $row_end, $period)
 with system versioning
 partition by range columns (x) (
     partition p0 values less than (100),
@@ -24,8 +29,10 @@ select * from t1 partition (p0) for system_time all;
 select * from t1 partition (p1) for system_time all;
 
 --echo # Engine change native <-> non-native versioning prohibited
---replace_result $default_engine DEFAULT_ENGINE
-eval create or replace table t1 (i int) engine=$default_engine with system versioning partition by hash(i);
+--replace_result $row_start ROW_START $row_end ROW_END $default_engine DEFAULT_ENGINE
+eval create or replace table t1 (i int, $row_start, $row_end, $period)
+engine=$default_engine
+with system versioning partition by hash(i);
 --replace_result $non_default_engine NON_DEFAULT_ENGINE
 --error ER_VERS_ALTER_ENGINE_PROHIBITED
 eval alter table t1 engine=$non_default_engine;
@@ -273,15 +280,17 @@ select * from t1 partition (p0sp1);
 select * from t1 partition (p1sp0);
 select * from t1 partition (p1sp1);
 
-create or replace table t1 (a bigint)
+--replace_result $row_start ROW_START $row_end ROW_END
+eval create or replace table t1 (a bigint, $row_start, $row_end, $period)
 with system versioning
 partition by range (a)
 (partition p0 values less than (20) engine innodb,
  partition p1 values less than maxvalue engine innodb);
 insert into t1 values (1);
 
-create or replace table t1 (
-  f_int1 integer default 0
+--replace_result $row_start ROW_START $row_end ROW_END
+eval create or replace table t1 (
+  f_int1 integer default 0, $row_start, $row_end, $period
 ) with system versioning
 partition by range(f_int1)
 subpartition by hash(f_int1)
@@ -291,7 +300,9 @@ subpartition subpart12 storage engine = 'innodb'));
 insert into t1 values (1);
 
 create or replace table t1 (i int) engine=innodb partition by key(i);
-alter table t1 add system versioning;
+--replace_result $row_start ROW_START $row_end ROW_END
+eval alter table t1 add column $row_start, add column $row_end, add $period,
+add system versioning;
 insert into t1 values();
 
 --echo # MDEV-14722 Assertion in ha_commit_trans for sub-statement
@@ -454,6 +465,78 @@ set sql_mode= ''; update t1 set v= 1;
 create or replace table t1 (i int) with system versioning partition by system_time limit 10 (partition p0 history, partition pn current);
 --error ER_VERS_QUERY_IN_PARTITION
 select * from t1 partition (p0) for system_time all;
+
+--echo # MDEV-15951 system versioning by trx id doesn't work with partitioning
+--echo # currently trx_id does not support partitioning by system_time
+--error ER_VERS_FIELD_WRONG_TYPE
+create or replace table t1(
+  i int,
+  row_start bigint unsigned generated always as row start,
+  row_end bigint unsigned generated always as row end,
+  period for system_time(row_start, row_end)
+) engine=InnoDB with system versioning partition by system_time (
+  partition p0 history,
+  partition pn current
+);
+
+create or replace table t1(
+  i int,
+  row_start bigint unsigned generated always as row start,
+  row_end bigint unsigned generated always as row end,
+  period for system_time(row_start, row_end)
+) engine=InnoDB with system versioning;
+--error ER_VERS_FIELD_WRONG_TYPE
+alter table t1  partition by system_time (
+  partition p0 history,
+  partition pn current
+);
+
+--error ER_VERS_NOT_SUPPORTED
+create or replace table t (
+  a int primary key,
+  row_start bigint unsigned as row start invisible,
+  row_end bigint unsigned as row end invisible,
+  period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by key() (
+  partition p1,
+  partition p2
+);
+
+--error ER_VERS_NOT_SUPPORTED
+create or replace table t (
+  a int primary key,
+  row_start bigint unsigned as row start invisible,
+  row_end bigint unsigned as row end invisible,
+  period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by key(a, row_start) (
+  partition p1,
+  partition p2
+);
+
+--error ER_VERS_NOT_SUPPORTED
+create or replace table t (
+  a int primary key,
+  row_start bigint unsigned as row start invisible,
+  row_end bigint unsigned as row end invisible,
+  period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by hash(a + row_end * 2) (
+  partition p1,
+  partition p2
+);
+
+--error ER_VERS_NOT_SUPPORTED
+create or replace table t (
+  a int primary key,
+  row_start bigint unsigned as row start invisible,
+  row_end bigint unsigned as row end invisible,
+  period for system_time(row_start, row_end)
+) engine=innodb with system versioning
+partition by range columns (a, row_start) (
+  partition p1 values less than (100, 100)
+);
 
 --echo # Test cleanup
 drop database test;

--- a/mysql-test/suite/versioning/t/update.test
+++ b/mysql-test/suite/versioning/t/update.test
@@ -144,6 +144,22 @@ update t1, t2 set t1.salary= 2500, t2.salary= 2500 where t1.id = t2.id and t1.na
 select @tmp1 = sys_trx_start as B1, salary from t1;
 select @tmp2 = sys_trx_start as B2, salary from t2;
 
+--echo #
+--echo # MDEV-17089 Updating a System Versioned Table always causes a row to be updated,
+--echo # regardless if the data is the same or not
+--echo #
+replace_result $sys_datatype_expl SYS_DATATYPE;
+eval create or replace table t1 (
+  x int primary key,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
+
+insert into t1 values (1);
+update t1 set x= 1;
+select * from t1 for system_time all;
+
 drop table t1;
 drop table t2;
 

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -413,6 +413,16 @@ public:
 
   virtual void return_record_by_parent();
 
+  virtual bool vers_can_native(THD *thd)
+  {
+    // PARTITION BY SYSTEM_TIME is not supported for now
+    bool can= !thd->lex->part_info
+              || thd->lex->part_info->part_type != VERSIONING_PARTITION;
+    for (uint i= 0; i < m_tot_parts && can; i++)
+      can= can && m_file[i]->vers_can_native(thd);
+    return can;
+  }
+
   /*
     -------------------------------------------------------------------------
     MODULE create/delete handler object

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -2062,8 +2062,6 @@ struct Table_scope_and_contents_source_st
                                 const Lex_table_name &table_name,
                                 const Lex_table_name &db);
 
-  bool vers_native(THD *thd) const;
-
   void init()
   {
     bzero(this, sizeof(*this));
@@ -3419,6 +3417,10 @@ public:
     return (pre_inited == INDEX ?
             ha_pre_index_end() :
             pre_inited == RND ? ha_pre_rnd_end() : 0 );
+  }
+  virtual bool vers_can_native(THD *thd)
+  {
+    return ht->flags & HTON_NATIVE_SYS_VERSIONING;
   }
 
   /**

--- a/sql/partition_element.h
+++ b/sql/partition_element.h
@@ -178,21 +178,6 @@ public:
     DBUG_ASSERT(ev->col_val_array);
     return ev->col_val_array[idx];
   }
-
-  bool find_engine_flag(uint32 flag)
-  {
-    if (ha_check_storage_engine_flag(engine_type, flag))
-      return true;
-
-    List_iterator_fast<partition_element> it(subpartitions);
-    while (partition_element *element= it++)
-    {
-      if (element->find_engine_flag(flag))
-        return true;
-    }
-
-    return false;
-  }
 };
 
 #endif /* PARTITION_ELEMENT_INCLUDED */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4584,6 +4584,7 @@ public:
                                    const char *path,
                                    const char *db,
                                    const char *table_name,
+                                   const char *orig_table_name,
                                    bool open_in_engine,
                                    bool open_internal_tables);
 
@@ -4622,7 +4623,8 @@ private:
                                 const char *table_name);
   TMP_TABLE_SHARE *create_temporary_table(handlerton *hton, LEX_CUSTRING *frm,
                                           const char *path, const char *db,
-                                          const char *table_name);
+                                          const char *table_name,
+                                          const char *orig_table_name);
   TABLE *find_temporary_table(const char *key, uint key_length,
                               Temporary_table_state state);
   TABLE *open_temporary_table(TMP_TABLE_SHARE *share, const char *alias,

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -341,7 +341,16 @@ static bool set_up_field_array(THD *thd, TABLE *table,
   while ((field= *(ptr++))) 
   {
     if (field->flags & GET_FIXED_FIELDS_FLAG)
+    {
+      if (table->versioned(VERS_TRX_ID)
+          && unlikely(field->flags & VERS_SYSTEM_FIELD))
+      {
+        my_error(ER_VERS_NOT_SUPPORTED, MYF(0),
+                 "Using ROW START/END for patitioning", "transactional");
+        DBUG_RETURN(TRUE);
+      }
       num_fields++;
+    }
   }
   if (unlikely(num_fields > MAX_REF_PARTS))
   {

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -4974,7 +4974,7 @@ int create_table_impl(THD *thd,
   {
     TABLE *table= thd->create_and_open_tmp_table(create_info->db_type, frm,
                                                  path, db->str,
-                                                 table_name->str, true,
+                                                 table_name->str, NULL, true,
                                                  false);
 
     if (!table)
@@ -5006,6 +5006,7 @@ int create_table_impl(THD *thd,
     TABLE_SHARE share;
 
     init_tmp_table_share(thd, &share, db->str, 0, table_name->str, path);
+    share.orig_table_name= orig_table_name->str;
 
     bool result= (open_table_def(thd, &share, GTS_TABLE) ||
                   open_table_from_share(thd, &share, &empty_clex_str, 0,
@@ -9647,6 +9648,7 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
                                          alter_ctx.get_tmp_path(),
                                          alter_ctx.new_db.str,
                                          alter_ctx.tmp_name.str,
+                                         alter_ctx.table_name.str,
                                          false, true)))
       goto err_new_table_cleanup;
 
@@ -9769,6 +9771,7 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
                                      alter_ctx.get_tmp_path(),
                                      alter_ctx.new_db.str,
                                      alter_ctx.tmp_name.str,
+                                     alter_ctx.table_name.str,
                                      true, true);
     if (!tmp_table)
     {
@@ -9802,6 +9805,7 @@ bool mysql_alter_table(THD *thd, const LEX_CSTRING *new_db,
                                      alter_ctx.get_tmp_path(),
                                      alter_ctx.new_db.str,
                                      alter_ctx.tmp_name.str,
+                                     alter_ctx.table_name.str,
                                      true, true);
   }
   if (!new_table)

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -65,7 +65,7 @@ bool records_are_comparable(const TABLE *table) {
    @return false otherwise.
 */
 
-bool compare_record(const TABLE *table)
+bool compare_record(const TABLE *table, uint32 skip_flags)
 {
   DBUG_ASSERT(records_are_comparable(table));
 
@@ -79,6 +79,8 @@ bool compare_record(const TABLE *table)
     for (Field **ptr= table->field ; *ptr != NULL; ptr++)
     {
       Field *field= *ptr;
+      if (skip_flags & field->flags)
+        continue;
       if (bitmap_is_set(table->write_set, field->field_index))
       {
         if (field->real_maybe_null())
@@ -101,7 +103,7 @@ bool compare_record(const TABLE *table)
      including those not in the write_set. This is cheaper than the
      field-by-field comparison done above.
   */ 
-  if (table->s->can_cmp_whole_record)
+  if (table->s->can_cmp_whole_record && !skip_flags)
     return cmp_record(table,record[1]);
   /* Compare null bits */
   if (memcmp(table->null_flags,
@@ -111,6 +113,8 @@ bool compare_record(const TABLE *table)
   /* Compare updated fields */
   for (Field **ptr= table->field ; *ptr ; ptr++)
   {
+    if (skip_flags & (*ptr)->flags)
+      continue;
     if (bitmap_is_set(table->write_set, (*ptr)->field_index) &&
 	(*ptr)->cmp_binary_offset(table->s->rec_buff_length))
       return TRUE;
@@ -318,6 +322,10 @@ int mysql_update_inner(THD *thd, TABLE_LIST *table_list, List<Item> &fields,
     my_error(ER_NON_UPDATABLE_TABLE, MYF(0), table_list->alias.str, "UPDATE");
     DBUG_RETURN(1);
   }
+
+  uint32 skip_flags= 0;
+  if (thd->lex->sql_command == SQLCOM_UPDATE && table->versioned_write(VERS_TIMESTAMP))
+    skip_flags= VERS_SYSTEM_FIELD;
 
   if (table->default_field)
     table->mark_default_fields_for_write(false);
@@ -817,7 +825,7 @@ update_begin:
 
       found++;
 
-      if (!can_compare_record || compare_record(table) ||
+      if (!can_compare_record || compare_record(table, skip_flags) ||
           thd->lex->sql_command == SQLCOM_DELETE)
       {
         if (table->versioned(VERS_TIMESTAMP) &&
@@ -2342,6 +2350,10 @@ int multi_update::send_data(List<Item> &not_used_values)
       bool can_compare_record;
       can_compare_record= records_are_comparable(table);
 
+      uint32 skip_flags= 0;
+      if (table->versioned_write(VERS_TIMESTAMP))
+        skip_flags= VERS_SYSTEM_FIELD;
+
       table->status|= STATUS_UPDATED;
       store_record(table,record[1]);
 
@@ -2356,7 +2368,7 @@ int multi_update::send_data(List<Item> &not_used_values)
       */
       table->auto_increment_field_not_null= FALSE;
       found++;
-      if (!can_compare_record || compare_record(table))
+      if (!can_compare_record || compare_record(table, skip_flags))
       {
 	int error;
 
@@ -2572,6 +2584,11 @@ int multi_update::do_updates()
     table = cur_table->table;
     if (table == table_to_update)
       continue;					// Already updated
+
+    uint32 skip_flags= 0;
+    if (table->versioned_write(VERS_TIMESTAMP))
+      skip_flags= VERS_SYSTEM_FIELD;
+
     org_updated= updated;
     tmp_table= tmp_tables[cur_table->shared];
     tmp_table->file->extra(HA_EXTRA_CACHE);	// Change to read cache
@@ -2685,7 +2702,7 @@ int multi_update::do_updates()
                                             TRG_ACTION_BEFORE, TRUE))
         goto err2;
 
-      if (!can_compare_record || compare_record(table))
+      if (!can_compare_record || compare_record(table, skip_flags))
       {
         int error;
         if (table->default_field &&

--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -44,6 +44,6 @@ bool mysql_multi_update(THD *thd, TABLE_LIST *table_list,
                         SELECT_LEX_UNIT *unit, SELECT_LEX *select_lex,
                         multi_update **result);
 bool records_are_comparable(const TABLE *table);
-bool compare_record(const TABLE *table);
+bool compare_record(const TABLE *table, uint32 skip_flags= 0);
 
 #endif /* SQL_UPDATE_INCLUDED */

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -1717,7 +1717,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
       goto err;
     DBUG_PRINT("info", ("Columns with system versioning: [%d, %d]", row_start, row_end));
     versioned= VERS_TIMESTAMP;
-    vers_can_native= plugin_hton(se_plugin)->flags & HTON_NATIVE_SYS_VERSIONING;
+    vers_can_native= handler_file->vers_can_native(thd);
     row_start_field= row_start;
     row_end_field= row_end;
     status_var_increment(thd->status_var.feature_system_versioning);
@@ -1971,7 +1971,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
         default:
           my_error(ER_VERS_FIELD_WRONG_TYPE, MYF(0), fieldnames.type_names[i],
             versioned == VERS_TIMESTAMP ? "TIMESTAMP(6)" : "BIGINT(20) UNSIGNED",
-            table_name.str);
+            error_table_name());
           goto err;
         }
       }

--- a/sql/temporary_tables.cc
+++ b/sql/temporary_tables.cc
@@ -54,6 +54,7 @@ bool THD::has_thd_temporary_tables()
   @param path [IN]                    File path (without extension)
   @param db   [IN]                    Schema name
   @param table_name [IN]              Table name
+  @param orig_table_name [IN]         Altered table original name
   @param open_in_engine [IN]          Whether open table in SE
 
 
@@ -65,6 +66,7 @@ TABLE *THD::create_and_open_tmp_table(handlerton *hton,
                                       const char *path,
                                       const char *db,
                                       const char *table_name,
+                                      const char *orig_table_name,
                                       bool open_in_engine,
                                       bool open_internal_tables)
 {
@@ -73,7 +75,8 @@ TABLE *THD::create_and_open_tmp_table(handlerton *hton,
   TMP_TABLE_SHARE *share;
   TABLE *table= NULL;
 
-  if ((share= create_temporary_table(hton, frm, path, db, table_name)))
+  if ((share= create_temporary_table(hton, frm, path, db, table_name,
+                                     orig_table_name)))
   {
     open_options|= HA_OPEN_FOR_CREATE;
     table= open_temporary_table(share, table_name, open_in_engine);
@@ -908,6 +911,7 @@ uint THD::create_tmp_table_def_key(char *key, const char *db,
   @param path [IN]                    File path (without extension)
   @param db   [IN]                    Schema name
   @param table_name [IN]              Table name
+  @param orig_table_name [IN]         Altered table original name
 
   @return Success                     A pointer to table share object
           Failure                     NULL
@@ -916,7 +920,8 @@ TMP_TABLE_SHARE *THD::create_temporary_table(handlerton *hton,
                                              LEX_CUSTRING *frm,
                                              const char *path,
                                              const char *db,
-                                             const char *table_name)
+                                             const char *table_name,
+                                             const char *orig_table_name)
 {
   DBUG_ENTER("THD::create_temporary_table");
 
@@ -950,6 +955,7 @@ TMP_TABLE_SHARE *THD::create_temporary_table(handlerton *hton,
 
   init_tmp_table_share(this, share, saved_key_cache, key_length,
                        strend(saved_key_cache) + 1, tmp_path);
+  share->orig_table_name= orig_table_name;
 
   share->db_plugin= ha_lock_engine(this, hton);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8298,6 +8298,7 @@ between old_row and new_row.
 @param[in]	buff_len	length of upd_buff
 @param[in,out]	prebuilt	InnoDB execution context
 @param[out]	auto_inc	updated AUTO_INCREMENT value, or 0 if none
+@param[out]	vers_n_changed	count of changed system fields
 @return DB_SUCCESS or error code */
 static
 dberr_t
@@ -8309,7 +8310,8 @@ calc_row_difference(
 	uchar*		upd_buff,
 	ulint		buff_len,
 	row_prebuilt_t*	prebuilt,
-	ib_uint64_t&	auto_inc)
+	ib_uint64_t&	auto_inc,
+	ulint&		vers_n_changed)
 {
 	uchar*		original_upd_buff = upd_buff;
 	Field*		field;
@@ -8339,6 +8341,7 @@ calc_row_difference(
 
 	clust_index = dict_table_get_first_index(prebuilt->table);
 	auto_inc = 0;
+	vers_n_changed = 0;
 
 	/* We use upd_buff to convert changed fields */
 	buf = (byte*) upd_buff;
@@ -8575,6 +8578,10 @@ calc_row_difference(
 				}
 			}
 			n_changed++;
+			if (field->flags & VERS_SYSTEM_FIELD)
+			{
+				vers_n_changed++;
+			}
 
 			/* If an FTS indexed column was changed by this
 			UPDATE then we need to inform the FTS sub-system.
@@ -8835,6 +8842,7 @@ ha_innobase::update_row(
 
 	upd_t*		uvect = row_get_prebuilt_update_vector(m_prebuilt);
 	ib_uint64_t	autoinc;
+	ib_uint64_t	vers_n_changed;
 
 	bool force_insert= table->versioned_write(VERS_TRX_ID)
 	                   && table->vers_start_id() == 0;
@@ -8854,7 +8862,7 @@ ha_innobase::update_row(
 
 	error = calc_row_difference(
 		uvect, old_row, new_row, table, m_upd_buf, m_upd_buf_size,
-		m_prebuilt, autoinc);
+		m_prebuilt, autoinc, vers_n_changed);
 
 	if (error != DB_SUCCESS) {
 		goto func_exit;
@@ -8867,17 +8875,24 @@ ha_innobase::update_row(
 		This is fix for http://bugs.mysql.com/29157 */
 		DBUG_RETURN(HA_ERR_RECORD_IS_THE_SAME);
 	} else {
+		const int sqlcom = thd_sql_command(m_user_thd);
 		const bool vers_set_fields = m_prebuilt->versioned_write
 			&& (m_prebuilt->upd_node->update->affects_versioned() || force_insert);
 		const bool vers_ins_row = vers_set_fields
-			&& thd_sql_command(m_user_thd) != SQLCOM_ALTER_TABLE;
+			&& sqlcom != SQLCOM_ALTER_TABLE;
 
 		if (vers_set_fields && !vers_ins_row) {
 			m_prebuilt->upd_node->is_delete = TRX_ID_DELETE;
-		} else if (thd_sql_command(m_user_thd) == SQLCOM_DELETE) {
+		} else if (sqlcom == SQLCOM_DELETE || sqlcom == SQLCOM_DELETE_MULTI) {
 			m_prebuilt->upd_node->is_delete = TIMESTAMP_DELETE;
 		} else {
 			m_prebuilt->upd_node->is_delete = NO_DELETE;
+		}
+
+		if ((sqlcom == SQLCOM_UPDATE || sqlcom == SQLCOM_UPDATE_MULTI) &&
+			uvect->n_fields == vers_n_changed &&
+			table->versioned_write(VERS_TIMESTAMP)) {
+			DBUG_RETURN(HA_ERR_RECORD_IS_THE_SAME);
 		}
 
 		innobase_srv_conc_enter_innodb(m_prebuilt);


### PR DESCRIPTION
MDEV-15951 system versioning by trx id doesn't work with partitioning

Fix partitioning for trx_id-versioned tables.
`partition by hash`, `range` and others now work.
`partition by system_time` is forbidden.
Currently we cannot use row_start and row_end in `partition by`, because
insertion of versioned field is done by engine's handler, as well as 
row_start/row_end's value set up, which is a transaction id -- so it's 
also forbidden.

The drawback is that it's now impossible to use `partition by key()`
without parameters for such tables, because it references row_start and
row_end implicitly.

* add handler::vers_can_native()
* drop Table_scope_and_contents_source_st::vers_native()
* drop partition_element::find_engine_flag as unused
* forbid versioning partitioning for trx_id as not supported
* adopt vers tests for trx_id partitioning
* forbid any row_end referencing in `partition by` clauses,
  including implicit `by key()`