### PR TITLE
Fix error-prone class arguments of printf-like functions

### DIFF
--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -796,7 +796,7 @@ int set_var::light_check(THD *thd)
   if (var->check_type(type))
   {
     int err= type == OPT_GLOBAL ? ER_LOCAL_VARIABLE : ER_GLOBAL_VARIABLE;
-    my_error(err, MYF(0), var->name);
+    my_error(err, MYF(0), var->name.str);
     return -1;
   }
   if (type == OPT_GLOBAL && check_global_access(thd, SUPER_ACL))

--- a/sql/sql_handler.cc
+++ b/sql/sql_handler.cc
@@ -670,7 +670,7 @@ mysql_ha_fix_cond_and_key(SQL_HANDLER *handler,
             (HA_READ_NEXT | HA_READ_PREV | HA_READ_RANGE)) == 0))
       {
         my_error(ER_KEY_DOESNT_SUPPORT, MYF(0),
-                 table->file->index_type(handler->keyno), keyinfo->name);
+                 table->file->index_type(handler->keyno), keyinfo->name.str);
         return 1;
       }
 
@@ -686,7 +686,7 @@ mysql_ha_fix_cond_and_key(SQL_HANDLER *handler,
                 HA_ONLY_WHOLE_INDEX))
       {
         my_error(ER_KEY_DOESNT_SUPPORT, MYF(0),
-                 table->file->index_type(handler->keyno), keyinfo->name);
+                 table->file->index_type(handler->keyno), keyinfo->name.str);
         return 1;
       }
 

--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -240,7 +240,7 @@ btr_root_block_get(
 			"Table %s in file %s is encrypted but encryption service or"
 			" used key_id is not available. "
 			" Can't continue reading table.",
-			index->table->name,
+			index->table->name.basename(),
 			UT_LIST_GET_FIRST(index->table->space->chain)->name);
 
 		return NULL;

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1310,7 +1310,7 @@ retry_page_get:
 				"Table %s is encrypted but encryption service or"
 				" used key_id is not available. "
 				" Can't continue reading table.",
-				index->table->name);
+				index->table->name.basename());
 			index->table->file_unreadable = true;
 		}
 
@@ -1423,7 +1423,7 @@ retry_page_get:
 						"Table %s is encrypted but encryption service or"
 						" used key_id is not available. "
 						" Can't continue reading table.",
-						index->table->name);
+						index->table->name.basename());
 					index->table->file_unreadable = true;
 				}
 
@@ -1452,7 +1452,7 @@ retry_page_get:
 					"Table %s is encrypted but encryption service or"
 					" used key_id is not available. "
 					" Can't continue reading table.",
-					index->table->name);
+					index->table->name.basename());
 				index->table->file_unreadable = true;
 			}
 
@@ -2359,7 +2359,7 @@ btr_cur_open_at_index_side_func(
 					"Table %s is encrypted but encryption service or"
 					" used key_id is not available. "
 					" Can't continue reading table.",
-					index->table->name);
+					index->table->name.basename());
 				index->table->file_unreadable = true;
 			}
 
@@ -2718,7 +2718,7 @@ btr_cur_open_at_rnd_pos_func(
 					"Table %s is encrypted but encryption service or"
 					" used key_id is not available. "
 					" Can't continue reading table.",
-					index->table->name);
+					index->table->name.basename());
 				index->table->file_unreadable = true;
 			}
 
@@ -5825,7 +5825,7 @@ btr_estimate_n_rows_in_range_on_level(
 					"Table %s is encrypted but encryption service or"
 					" used key_id is not available. "
 					" Can't continue reading table.",
-					index->table->name);
+					index->table->name.basename());
 				index->table->file_unreadable = true;
 			}
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14347,7 +14347,7 @@ ha_innobase::optimize(
 			push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
 					    uint(err),
 				"InnoDB: Cannot defragment table %s: returned error code %d\n",
-				m_prebuilt->table->name, err);
+				m_prebuilt->table->name.basename(), err);
 
 			if(err == ER_SP_ALREADY_EXISTS) {
 				try_alter = false;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -6628,7 +6628,7 @@ found_fk:
 					Sql_condition::WARN_LEVEL_WARN,
 					HA_ERR_WRONG_INDEX,
 					"InnoDB could not find key"
-					" with name %s", key->name);
+					" with name %s", key->name.str);
 			} else {
 				ut_ad(!index->to_be_dropped);
 				if (!index->is_primary()) {

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2988,7 +2988,7 @@ row_ins_sec_index_entry_low(
 				"Table %s is encrypted but encryption service or"
 				" used key_id is not available. "
 				" Can't continue reading table.",
-				index->table->name);
+				index->table->name.basename());
 			index->table->file_unreadable = true;
 		}
 		goto func_exit;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1304,7 +1304,7 @@ row_mysql_get_table_status(
 					"Table %s in tablespace %lu encrypted."
 					"However key management plugin or used key_id is not found or"
 					" used encryption algorithm or method does not match.",
-					table->name, table->space);
+					table->name.basename(), table->space);
 			}
 
 			err = DB_DECRYPTION_FAILED;
@@ -1312,7 +1312,7 @@ row_mysql_get_table_status(
 			if (push_warning) {
 				ib_push_warning(trx, DB_CORRUPTION,
 					"Table %s in tablespace %lu corrupted.",
-					table->name, table->space);
+					table->name.basename(), table->space);
 			}
 
 			err = DB_CORRUPTION;

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -4658,7 +4658,7 @@ wait_table_again:
 					"Table %s is encrypted but encryption service or"
 					" used key_id is not available. "
 					" Can't continue reading table.",
-					prebuilt->table->name);
+					prebuilt->table->name.basename());
 				index->table->file_unreadable = true;
 			}
 			rec = NULL;


### PR DESCRIPTION
Several portability-sensitive errors are fixed after building with clang's `-Wclass-varargs`

There were several types of such arguments: `table_name_t` and `LEX_CSTRING`/`Lex_ident`.

* `LEX_CSTRING`s are 100% error-prone, and lead to stack bereakage. The reason why it is not breaking all the time as far as I see is that x86 ABI requires 16-byte stack frame alignment, or maybe with the help of frame pointers.

* `table_name_t` looks safer, as it's only member is char*. But still structure alignment is implementation defined, and while it is safe for x86 and ARM ABIs, it is not portable in general and thus passing it to printf-like varargs is UB