### PR TITLE
MDEV-16978 Application period tables: WITHOUT OVERLAPS

### DIFF
--- a/mysql-test/suite/period/r/create.result
+++ b/mysql-test/suite/period/r/create.result
@@ -8,8 +8,8 @@ t	CREATE TABLE `t` (
   `id` int(11) NOT NULL,
   `s` date NOT NULL,
   `e` date NOT NULL,
-  PRIMARY KEY (`id`),
-  PERIOD FOR `mytime` (`s`, `e`)
+  PERIOD FOR `mytime` (`s`, `e`),
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 create or replace table t (id int primary key, s timestamp(6), e timestamp(6),
 period for mytime(s,e));
@@ -19,8 +19,8 @@ t	CREATE TABLE `t` (
   `id` int(11) NOT NULL,
   `s` timestamp(6) NOT NULL DEFAULT '0000-00-00 00:00:00.000000',
   `e` timestamp(6) NOT NULL DEFAULT '0000-00-00 00:00:00.000000',
-  PRIMARY KEY (`id`),
-  PERIOD FOR `mytime` (`s`, `e`)
+  PERIOD FOR `mytime` (`s`, `e`),
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 # SQL17 p. 832
 # 2) If a <table period definition> TPD is specified, then:

--- a/mysql-test/suite/period/r/overlaps.result
+++ b/mysql-test/suite/period/r/overlaps.result
@@ -149,17 +149,7 @@ t1	CREATE TABLE `t1` (
 create or replace table t1 (x int, s date, e date,
 period for p(s,e),
 primary key(x, p without overlaps)
-) with system versioning
-partition by key (x);
-ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
-create or replace table t1 (x int, s date, e date,
-period for p(s,e),
-primary key(x, p without overlaps)
-) with system versioning
-partition by system_time limit 2
-(partition p0 history,
-partition p1 history,
-partition pn current);
+) partition by key (x);
 ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
 create or replace table t1 (x int, s date, e date,
 period for p(s,e),

--- a/mysql-test/suite/period/r/overlaps.result
+++ b/mysql-test/suite/period/r/overlaps.result
@@ -1,13 +1,15 @@
 create or replace table t(id int, s date, e date,
 period for p(s,e),
 primary key(id, p without overlaps));
-# store some irrelevant data
-insert into t values (1, '2002-01-01', '2002-02-01'),
-(1, '2002-02-01', '2002-03-01'),
-(1, '2002-03-01', '2002-04-01'),
-(1, '2004-01-01', '2004-02-01'),
-(1, '2004-02-01', '2004-03-01'),
-(1, '2004-03-01', '2004-04-01');
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int(11) NOT NULL,
+  `s` date NOT NULL,
+  `e` date NOT NULL,
+  PERIOD FOR `p` (`s`, `e`),
+  PRIMARY KEY (`id`,`p` WITHOUT OVERLAPS)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t values (1, '2003-01-01', '2003-03-01'),
 (1, '2003-05-01', '2003-07-01');
 insert into t values (1, '2003-02-01', '2003-04-01');
@@ -58,6 +60,13 @@ period for p(s,e),
 primary key(id, q without overlaps));
 ERROR HY000: period `q` is not found in table
 create or replace table t(id int, s date, e date,
+primary key(id, p without overlaps));
+ERROR HY000: period `p` is not found in table
+create or replace table t(id int, s date, e date,
+period for p(s,e),
+primary key(id, s, p without overlaps));
+ERROR HY000: Key `(null)` should not contain period fields in order to make it WITHOUT OVERLAPS
+create or replace table t(id int, s date, e date,
 period for p(s,e),
 primary key(id));
 insert into t values (1, '2003-03-01', '2003-05-01');
@@ -67,6 +76,17 @@ create or replace table t(id int, u int, s date, e date,
 period for p(s,e),
 primary key(id, p without overlaps),
 unique(u));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int(11) NOT NULL,
+  `u` int(11) DEFAULT NULL,
+  `s` date NOT NULL,
+  `e` date NOT NULL,
+  PERIOD FOR `p` (`s`, `e`),
+  PRIMARY KEY (`id`,`p` WITHOUT OVERLAPS),
+  UNIQUE KEY `u` (`u`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t values (1, 1, '2003-03-01', '2003-05-01');
 insert into t values (1, 2, '2003-05-01', '2003-07-01');
 insert into t values (1, 3, '2003-04-01', '2003-05-01');
@@ -75,7 +95,47 @@ create or replace table t(id int, u int, s date, e date,
 period for p(s,e),
 primary key(id, p without overlaps),
 unique(u, p without overlaps));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int(11) NOT NULL,
+  `u` int(11) DEFAULT NULL,
+  `s` date NOT NULL,
+  `e` date NOT NULL,
+  PERIOD FOR `p` (`s`, `e`),
+  PRIMARY KEY (`id`,`p` WITHOUT OVERLAPS),
+  UNIQUE KEY `u` (`u`,`p` WITHOUT OVERLAPS)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t values (1, 1, '2003-03-01', '2003-05-01');
 insert into t values (1, 2, '2003-05-01', '2003-07-01');
 insert into t values (2, 1, '2003-05-01', '2003-07-01');
+create or replace table t(id int, s date, e date,
+period for p(s,e)) engine=innodb;
+insert into t values (1, '2003-01-01', '2003-03-01'),
+(1, '2003-05-01', '2003-07-01'),
+(1, '2003-02-01', '2003-04-01');
+alter table t add primary key(id, p without overlaps);
+ERROR 23000: Can't write; duplicate key in table '#sql-temp'
+# Historical rows are not checked against constraints
+set @@system_versioning_alter_history= keep;
+alter table t add system versioning;
+delete from t;
+alter table t add primary key(id, p without overlaps);
+insert into t values (1, '2003-01-01', '2003-03-01'),
+(1, '2003-03-01', '2003-05-01');
+create or replace table t1 (x int, s date, e date,
+period for p(s,e),
+primary key(x, p without overlaps)
+) with system versioning
+partition by key (x);
+ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
+create or replace table t1 (x int, s date, e date,
+period for p(s,e),
+primary key(x, p without overlaps)
+) with system versioning
+partition by system_time limit 2
+(partition p0 history,
+partition p1 history,
+partition pn current);
+ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
 create or replace database test;

--- a/mysql-test/suite/period/r/overlaps.result
+++ b/mysql-test/suite/period/r/overlaps.result
@@ -160,4 +160,8 @@ create or replace table t1 (x int, s date, e date, period for p (s, e))
 partition by hash (x);
 alter table t1 add primary key (x, p without overlaps);
 ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
+create or replace table t2 (x int, s date, e date,
+period for p (s, e),
+key(x, p without overlaps));
+ERROR HY000: Period WITHOUT OVERLAPS is only allowed for unique keys
 create or replace database test;

--- a/mysql-test/suite/period/r/overlaps.result
+++ b/mysql-test/suite/period/r/overlaps.result
@@ -123,6 +123,29 @@ delete from t;
 alter table t add primary key(id, p without overlaps);
 insert into t values (1, '2003-01-01', '2003-03-01'),
 (1, '2003-03-01', '2003-05-01');
+# `without overlaps` is not lost on alter table
+alter table t add y int;
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int(11) NOT NULL,
+  `s` date NOT NULL,
+  `e` date NOT NULL,
+  `y` int(11) DEFAULT NULL,
+  PERIOD FOR `p` (`s`, `e`),
+  PRIMARY KEY (`id`,`p` WITHOUT OVERLAPS)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
+alter table t drop y;
+create or replace table t1 like t;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL,
+  `s` date NOT NULL,
+  `e` date NOT NULL,
+  PERIOD FOR `p` (`s`, `e`),
+  PRIMARY KEY (`id`,`p` WITHOUT OVERLAPS)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
 create or replace table t1 (x int, s date, e date,
 period for p(s,e),
 primary key(x, p without overlaps)
@@ -137,5 +160,14 @@ partition by system_time limit 2
 (partition p0 history,
 partition p1 history,
 partition pn current);
+ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
+create or replace table t1 (x int, s date, e date,
+period for p(s,e),
+primary key(x, p without overlaps));
+alter table t1 partition by key (x);
+ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
+create or replace table t1 (x int, s date, e date, period for p (s, e))
+partition by hash (x);
+alter table t1 add primary key (x, p without overlaps);
 ERROR HY000: Period WITHOUT OVERLAPS is not implemented for partitioned tables
 create or replace database test;

--- a/mysql-test/suite/period/r/overlaps.result
+++ b/mysql-test/suite/period/r/overlaps.result
@@ -1,0 +1,81 @@
+create or replace table t(id int, s date, e date,
+period for p(s,e),
+primary key(id, p without overlaps));
+# store some irrelevant data
+insert into t values (1, '2002-01-01', '2002-02-01'),
+(1, '2002-02-01', '2002-03-01'),
+(1, '2002-03-01', '2002-04-01'),
+(1, '2004-01-01', '2004-02-01'),
+(1, '2004-02-01', '2004-03-01'),
+(1, '2004-03-01', '2004-04-01');
+insert into t values (1, '2003-01-01', '2003-03-01'),
+(1, '2003-05-01', '2003-07-01');
+insert into t values (1, '2003-02-01', '2003-04-01');
+ERROR 23000: Can't write; duplicate key in table 't'
+insert into t values (1, '2003-04-01', '2003-06-01');
+ERROR 23000: Can't write; duplicate key in table 't'
+insert into t values (1, '2003-05-15', '2003-06-15');
+ERROR 23000: Can't write; duplicate key in table 't'
+insert into t values (1, '2003-04-01', '2003-08-01');
+ERROR 23000: Can't write; duplicate key in table 't'
+insert into t values (1, '2003-03-01', '2003-05-01');
+# expand/shrink period
+update t set s= '2002-12-01' where s = '2003-01-01';
+update t set s= '2003-01-01' where s = '2002-12-01';
+update t set e= '2003-08-01' where s = '2003-05-01';
+update t set e= '2003-07-01' where s = '2003-05-01';
+# move left/right
+update t set s= '2002-12-15', e= '2003-01-15' where s = '2003-01-01';
+update t set s= '2003-01-01', e= '2003-02-01' where s = '2002-12-15';
+# diminish/enlarge
+update t set s= '2003-01-10', e= '2003-01-20' where s = '2003-01-01';
+update t set s= '2003-01-01', e= '2003-02-01' where s = '2003-01-10';
+# intersect left/right, strict inclusion/containment
+update t set e= '2003-04-01' where s = '2003-01-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set s= '2003-04-01' where s = '2003-05-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set s= '2003-03-10', e= '2003-03-20' where s = '2003-01-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set s= '2003-04-01', e= '2003-08-01' where s = '2003-03-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+# inclusion/containment with partial match
+update t set s= '2003-03-01', e= '2003-04-01' where s = '2003-01-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set s= '2003-04-01', e= '2003-05-01' where s = '2003-01-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set s= '2003-03-01' where s = '2003-05-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+update t set e= '2003-05-01' where s = '2003-01-01';
+ERROR 23000: Can't write; duplicate key in table 't'
+select * from t where year(s) = 2003;
+id	s	e
+1	2003-01-01	2003-02-01
+1	2003-03-01	2003-05-01
+1	2003-05-01	2003-07-01
+create or replace table t(id int, s date, e date,
+period for p(s,e),
+primary key(id, q without overlaps));
+ERROR HY000: period `q` is not found in table
+create or replace table t(id int, s date, e date,
+period for p(s,e),
+primary key(id));
+insert into t values (1, '2003-03-01', '2003-05-01');
+insert into t values (1, '2003-04-01', '2003-05-01');
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+create or replace table t(id int, u int, s date, e date,
+period for p(s,e),
+primary key(id, p without overlaps),
+unique(u));
+insert into t values (1, 1, '2003-03-01', '2003-05-01');
+insert into t values (1, 2, '2003-05-01', '2003-07-01');
+insert into t values (1, 3, '2003-04-01', '2003-05-01');
+ERROR 23000: Can't write; duplicate key in table 't'
+create or replace table t(id int, u int, s date, e date,
+period for p(s,e),
+primary key(id, p without overlaps),
+unique(u, p without overlaps));
+insert into t values (1, 1, '2003-03-01', '2003-05-01');
+insert into t values (1, 2, '2003-05-01', '2003-07-01');
+insert into t values (2, 1, '2003-05-01', '2003-07-01');
+create or replace database test;

--- a/mysql-test/suite/period/t/overlaps.test
+++ b/mysql-test/suite/period/t/overlaps.test
@@ -1,14 +1,12 @@
+--source include/have_innodb.inc
+--source include/have_partition.inc
+
 create or replace table t(id int, s date, e date,
                           period for p(s,e),
                           primary key(id, p without overlaps));
 
---echo # store some irrelevant data
-insert into t values (1, '2002-01-01', '2002-02-01'),
-                     (1, '2002-02-01', '2002-03-01'),
-                     (1, '2002-03-01', '2002-04-01'),
-                     (1, '2004-01-01', '2004-02-01'),
-                     (1, '2004-02-01', '2004-03-01'),
-                     (1, '2004-03-01', '2004-04-01');
+show create table t;
+
 
 insert into t values (1, '2003-01-01', '2003-03-01'),
                      (1, '2003-05-01', '2003-07-01');
@@ -66,6 +64,15 @@ create or replace table t(id int, s date, e date,
                           period for p(s,e),
                           primary key(id, q without overlaps));
 
+--error ER_PERIOD_NOT_FOUND
+create or replace table t(id int, s date, e date,
+                          primary key(id, p without overlaps));
+
+--error ER_KEY_CONTAINS_PERIOD_FIELDS
+create or replace table t(id int, s date, e date,
+                          period for p(s,e),
+                          primary key(id, s, p without overlaps));
+
 create or replace table t(id int, s date, e date,
                           period for p(s,e),
                           primary key(id));
@@ -77,6 +84,7 @@ create or replace table t(id int, u int, s date, e date,
                           period for p(s,e),
                           primary key(id, p without overlaps),
                           unique(u));
+show create table t;
 insert into t values (1, 1, '2003-03-01', '2003-05-01');
 insert into t values (1, 2, '2003-05-01', '2003-07-01');
 --error ER_DUP_KEY
@@ -86,8 +94,46 @@ create or replace table t(id int, u int, s date, e date,
                           period for p(s,e),
                           primary key(id, p without overlaps),
                           unique(u, p without overlaps));
+show create table t;
 insert into t values (1, 1, '2003-03-01', '2003-05-01');
 insert into t values (1, 2, '2003-05-01', '2003-07-01');
 insert into t values (2, 1, '2003-05-01', '2003-07-01');
+
+create or replace table t(id int, s date, e date,
+                          period for p(s,e)) engine=innodb;
+
+insert into t values (1, '2003-01-01', '2003-03-01'),
+                     (1, '2003-05-01', '2003-07-01'),
+                     (1, '2003-02-01', '2003-04-01');
+
+--replace_regex /#sql-\w+/#sql-temp/
+--error ER_DUP_KEY
+alter table t add primary key(id, p without overlaps);
+
+--echo # Historical rows are not checked against constraints
+set @@system_versioning_alter_history= keep;
+alter table t add system versioning;
+delete from t;
+alter table t add primary key(id, p without overlaps);
+
+insert into t values (1, '2003-01-01', '2003-03-01'),
+                     (1, '2003-03-01', '2003-05-01');
+
+--error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
+create or replace table t1 (x int, s date, e date,
+                            period for p(s,e),
+                            primary key(x, p without overlaps)
+) with system versioning
+  partition by key (x);
+
+--error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
+create or replace table t1 (x int, s date, e date,
+                            period for p(s,e),
+                            primary key(x, p without overlaps)
+) with system versioning
+  partition by system_time limit 2
+  (partition p0 history,
+   partition p1 history,
+   partition pn current);
 
 create or replace database test;

--- a/mysql-test/suite/period/t/overlaps.test
+++ b/mysql-test/suite/period/t/overlaps.test
@@ -119,6 +119,15 @@ alter table t add primary key(id, p without overlaps);
 insert into t values (1, '2003-01-01', '2003-03-01'),
                      (1, '2003-03-01', '2003-05-01');
 
+
+--echo # `without overlaps` is not lost on alter table
+alter table t add y int;
+show create table t;
+alter table t drop y;
+
+create or replace table t1 like t;
+show create table t1;
+
 --error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
 create or replace table t1 (x int, s date, e date,
                             period for p(s,e),
@@ -135,5 +144,16 @@ create or replace table t1 (x int, s date, e date,
   (partition p0 history,
    partition p1 history,
    partition pn current);
+
+create or replace table t1 (x int, s date, e date,
+                            period for p(s,e),
+                            primary key(x, p without overlaps));
+--error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
+alter table t1 partition by key (x);
+
+create or replace table t1 (x int, s date, e date, period for p (s, e))
+                           partition by hash (x);
+--error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
+alter table t1 add primary key (x, p without overlaps);
 
 create or replace database test;

--- a/mysql-test/suite/period/t/overlaps.test
+++ b/mysql-test/suite/period/t/overlaps.test
@@ -145,4 +145,9 @@ create or replace table t1 (x int, s date, e date, period for p (s, e))
 --error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
 alter table t1 add primary key (x, p without overlaps);
 
+--error ER_PERIOD_WITHOUT_OVERLAPS_NON_UNIQUE
+create or replace table t2 (x int, s date, e date,
+                            period for p (s, e),
+                            key(x, p without overlaps));
+
 create or replace database test;

--- a/mysql-test/suite/period/t/overlaps.test
+++ b/mysql-test/suite/period/t/overlaps.test
@@ -1,0 +1,93 @@
+create or replace table t(id int, s date, e date,
+                          period for p(s,e),
+                          primary key(id, p without overlaps));
+
+--echo # store some irrelevant data
+insert into t values (1, '2002-01-01', '2002-02-01'),
+                     (1, '2002-02-01', '2002-03-01'),
+                     (1, '2002-03-01', '2002-04-01'),
+                     (1, '2004-01-01', '2004-02-01'),
+                     (1, '2004-02-01', '2004-03-01'),
+                     (1, '2004-03-01', '2004-04-01');
+
+insert into t values (1, '2003-01-01', '2003-03-01'),
+                     (1, '2003-05-01', '2003-07-01');
+
+--error ER_DUP_KEY
+insert into t values (1, '2003-02-01', '2003-04-01');
+--error ER_DUP_KEY
+insert into t values (1, '2003-04-01', '2003-06-01');
+--error ER_DUP_KEY
+insert into t values (1, '2003-05-15', '2003-06-15');
+--error ER_DUP_KEY
+insert into t values (1, '2003-04-01', '2003-08-01');
+
+insert into t values (1, '2003-03-01', '2003-05-01');
+
+--echo # expand/shrink period
+update t set s= '2002-12-01' where s = '2003-01-01';
+update t set s= '2003-01-01' where s = '2002-12-01';
+
+update t set e= '2003-08-01' where s = '2003-05-01';
+update t set e= '2003-07-01' where s = '2003-05-01';
+
+--echo # move left/right
+update t set s= '2002-12-15', e= '2003-01-15' where s = '2003-01-01';
+update t set s= '2003-01-01', e= '2003-02-01' where s = '2002-12-15';
+
+--echo # diminish/enlarge
+update t set s= '2003-01-10', e= '2003-01-20' where s = '2003-01-01';
+update t set s= '2003-01-01', e= '2003-02-01' where s = '2003-01-10';
+
+--echo # intersect left/right, strict inclusion/containment
+--error ER_DUP_KEY
+update t set e= '2003-04-01' where s = '2003-01-01';
+--error ER_DUP_KEY
+update t set s= '2003-04-01' where s = '2003-05-01';
+--error ER_DUP_KEY
+update t set s= '2003-03-10', e= '2003-03-20' where s = '2003-01-01';
+--error ER_DUP_KEY
+update t set s= '2003-04-01', e= '2003-08-01' where s = '2003-03-01';
+
+--echo # inclusion/containment with partial match
+--error ER_DUP_KEY
+update t set s= '2003-03-01', e= '2003-04-01' where s = '2003-01-01';
+--error ER_DUP_KEY
+update t set s= '2003-04-01', e= '2003-05-01' where s = '2003-01-01';
+--error ER_DUP_KEY
+update t set s= '2003-03-01' where s = '2003-05-01';
+--error ER_DUP_KEY
+update t set e= '2003-05-01' where s = '2003-01-01';
+
+select * from t where year(s) = 2003;
+
+--error ER_PERIOD_NOT_FOUND
+create or replace table t(id int, s date, e date,
+                          period for p(s,e),
+                          primary key(id, q without overlaps));
+
+create or replace table t(id int, s date, e date,
+                          period for p(s,e),
+                          primary key(id));
+insert into t values (1, '2003-03-01', '2003-05-01');
+--error ER_DUP_ENTRY
+insert into t values (1, '2003-04-01', '2003-05-01');
+
+create or replace table t(id int, u int, s date, e date,
+                          period for p(s,e),
+                          primary key(id, p without overlaps),
+                          unique(u));
+insert into t values (1, 1, '2003-03-01', '2003-05-01');
+insert into t values (1, 2, '2003-05-01', '2003-07-01');
+--error ER_DUP_KEY
+insert into t values (1, 3, '2003-04-01', '2003-05-01');
+
+create or replace table t(id int, u int, s date, e date,
+                          period for p(s,e),
+                          primary key(id, p without overlaps),
+                          unique(u, p without overlaps));
+insert into t values (1, 1, '2003-03-01', '2003-05-01');
+insert into t values (1, 2, '2003-05-01', '2003-07-01');
+insert into t values (2, 1, '2003-05-01', '2003-07-01');
+
+create or replace database test;

--- a/mysql-test/suite/period/t/overlaps.test
+++ b/mysql-test/suite/period/t/overlaps.test
@@ -132,18 +132,7 @@ show create table t1;
 create or replace table t1 (x int, s date, e date,
                             period for p(s,e),
                             primary key(x, p without overlaps)
-) with system versioning
-  partition by key (x);
-
---error ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
-create or replace table t1 (x int, s date, e date,
-                            period for p(s,e),
-                            primary key(x, p without overlaps)
-) with system versioning
-  partition by system_time limit 2
-  (partition p0 history,
-   partition p1 history,
-   partition pn current);
+) partition by key (x);
 
 create or replace table t1 (x int, s date, e date,
                             period for p(s,e),

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1908,9 +1908,10 @@ enum vers_sys_type_t
 
 struct Table_period_info: Sql_alloc
 {
-  Table_period_info() {}
+  Table_period_info(): unique_keys(0) {}
   Table_period_info(const char *name_arg, size_t size) :
-    name(name_arg, size) {}
+    name(name_arg, size),
+    unique_keys(0){}
 
   Lex_ident name;
 
@@ -1924,6 +1925,7 @@ struct Table_period_info: Sql_alloc
     Lex_ident end;
   };
   start_end_t period;
+  uint unique_keys;
 
   bool is_set() const
   {
@@ -2868,6 +2870,8 @@ protected:
   Table_flags cached_table_flags;       /* Set on init() and open() */
 
   ha_rows estimation_rows_to_insert;
+  uchar *check_overlaps_buffer;
+  handler *check_overlaps_handler;
 public:
   handlerton *ht;                 /* storage engine of this handler */
   uchar *ref;				/* Pointer to current row */
@@ -3002,8 +3006,9 @@ private:
 public:
   handler(handlerton *ht_arg, TABLE_SHARE *share_arg)
     :table_share(share_arg), table(0),
-    estimation_rows_to_insert(0), ht(ht_arg),
-    ref(0), end_range(NULL),
+    estimation_rows_to_insert(0),
+    check_overlaps_buffer(NULL), check_overlaps_handler(NULL),
+    ht(ht_arg), ref(0), end_range(NULL),
     implicit_emptied(0),
     mark_trx_read_write_done(0),
     check_table_binlog_row_based_done(0),
@@ -3107,6 +3112,8 @@ public:
     The cached_table_flags is set at ha_open and ha_external_lock
   */
   Table_flags ha_table_flags() const { return cached_table_flags; }
+  /** PRIMARY KEY WITHOUT OVERLAPS check is done globally */
+  int ha_check_overlaps(const uchar *old_data, const uchar* new_data);
   /**
     These functions represent the public interface to *users* of the
     handler class, hence they are *not* virtual. For the inheritance

--- a/sql/key.cc
+++ b/sql/key.cc
@@ -112,7 +112,7 @@ int find_ref_key(KEY *key, uint key_count, uchar *record, Field *field,
   @param with_zerofill  skipped bytes in the key buffer to be filled with 0
 */
 
-void key_copy(uchar *to_key, const uchar *from_record, KEY *key_info,
+void key_copy(uchar *to_key, const uchar *from_record, const KEY *key_info,
               uint key_length, bool with_zerofill)
 {
   uint length;

--- a/sql/key.h
+++ b/sql/key.h
@@ -25,7 +25,7 @@ typedef struct st_key_part_info KEY_PART_INFO;
 
 int find_ref_key(KEY *key, uint key_count, uchar *record, Field *field,
                  uint *key_length, uint *keypart);
-void key_copy(uchar *to_key, const uchar *from_record, KEY *key_info,
+void key_copy(uchar *to_key, const uchar *from_record, const KEY *key_info,
               uint key_length, bool with_zerofill= FALSE);
 void key_restore(uchar *to_record, const uchar *from_key, KEY *key_info,
                  uint key_length);

--- a/sql/lex.h
+++ b/sql/lex.h
@@ -456,6 +456,7 @@ static SYMBOL symbols[] = {
   { "OUTER",		SYM(OUTER)},
   { "OUTFILE",		SYM(OUTFILE)},
   { "OVER",             SYM(OVER_SYM)},
+  { "OVERLAPS",         SYM(OVERLAPS)},
   { "OWNER",		SYM(OWNER_SYM)},
   { "PACKAGE",          SYM(PACKAGE_SYM)},
   { "PACK_KEYS",	SYM(PACK_KEYS_SYM)},

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7972,3 +7972,6 @@ ER_KEY_CONTAINS_PERIOD_FIELDS
 
 ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
         eng "Period WITHOUT OVERLAPS is not implemented for partitioned tables"
+
+ER_PERIOD_WITHOUT_OVERLAPS_NON_UNIQUE
+        eng "Period WITHOUT OVERLAPS is only allowed for unique keys"

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7966,3 +7966,6 @@ ER_PERIOD_CONSTRAINT_DROP
 
 ER_PERIOD_FIELD_ACCESS_BY_CONSTRAINT
         eng "CONSTRAINT `%s` uses fields from PERIOD `%s`"
+
+ER_KEY_CONTAINS_PERIOD_FIELDS
+        eng "Key %`s should not contain period fields in order to make it WITHOUT OVERLAPS"

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7969,3 +7969,6 @@ ER_PERIOD_FIELD_ACCESS_BY_CONSTRAINT
 
 ER_KEY_CONTAINS_PERIOD_FIELDS
         eng "Key %`s should not contain period fields in order to make it WITHOUT OVERLAPS"
+
+ER_PERIOD_WITHOUT_OVERLAPS_PARTITIONED
+        eng "Period WITHOUT OVERLAPS is not implemented for partitioned tables"

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -139,7 +139,8 @@ Key::Key(const Key &rhs, MEM_ROOT *mem_root)
   columns(rhs.columns, mem_root),
   name(rhs.name),
   option_list(rhs.option_list),
-  generated(rhs.generated), invisible(false)
+  generated(rhs.generated), invisible(false),
+  without_overlaps(rhs.without_overlaps), period(rhs.period)
 {
   list_copy_and_replace_each_value(columns, mem_root);
 }

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -324,13 +324,15 @@ public:
   engine_option_value *option_list;
   bool generated;
   bool invisible;
+  bool without_overlaps;
+  Lex_ident period;
 
   Key(enum Keytype type_par, const LEX_CSTRING *name_arg,
       ha_key_alg algorithm_arg, bool generated_arg, DDL_options_st ddl_options)
     :DDL_options(ddl_options),
      type(type_par), key_create_info(default_key_create_info),
     name(*name_arg), option_list(NULL), generated(generated_arg),
-    invisible(false)
+    invisible(false), without_overlaps(false)
   {
     key_create_info.algorithm= algorithm_arg;
   }
@@ -341,7 +343,7 @@ public:
     :DDL_options(ddl_options),
      type(type_par), key_create_info(*key_info_arg), columns(*cols),
     name(*name_arg), option_list(create_opt), generated(generated_arg),
-    invisible(false)
+    invisible(false), without_overlaps(false)
   {}
   Key(const Key &rhs, MEM_ROOT *mem_root);
   virtual ~Key() {}

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -4460,9 +4460,18 @@ static bool append_system_key_parts(THD *thd, HA_CREATE_INFO *create_info,
       if (!key_part)
         key->columns.push_back(new Key_part_spec(&row_end_field, 0));
     }
+  }
 
+  key_it.rewind();
+  while ((key=key_it++))
+  {
     if (key->without_overlaps)
     {
+      if (key->type != Key::PRIMARY && key->type != Key::UNIQUE)
+      {
+        my_error(ER_PERIOD_WITHOUT_OVERLAPS_NON_UNIQUE, MYF(0), key->period.str);
+        return true;
+      }
       if (!create_info->period_info.is_set()
           || !key->period.streq(create_info->period_info.name))
       {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1027,6 +1027,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
 %token  OUTFILE
 %token  OUT_SYM                       /* SQL-2003-R */
 %token  OVER_SYM
+%token  OVERLAPS
 %token  PAGE_CHECKSUM_SYM
 %token  PARAM_MARKER
 %token  PARSE_VCOL_EXPR_SYM
@@ -7630,6 +7631,11 @@ key_list:
           key_list ',' key_part order_dir
           {
             Lex->last_key->columns.push_back($3, thd->mem_root);
+          }
+        | key_list ',' ident WITHOUT OVERLAPS
+          {
+            Lex->last_key->without_overlaps= true;
+            Lex->last_key->period= $3;
           }
         | key_part order_dir
           {

--- a/sql/sql_yacc_ora.yy
+++ b/sql/sql_yacc_ora.yy
@@ -506,6 +506,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
 %token  OUTFILE
 %token  OUT_SYM                       /* SQL-2003-R */
 %token  OVER_SYM
+%token  OVERLAPS
 %token  PAGE_CHECKSUM_SYM
 %token  PARAM_MARKER
 %token  PARSE_VCOL_EXPR_SYM
@@ -7755,6 +7756,11 @@ key_list:
           key_list ',' key_part order_dir
           {
             Lex->last_key->columns.push_back($3, thd->mem_root);
+          }
+        | key_list ',' ident WITHOUT OVERLAPS
+          {
+            Lex->last_key->without_overlaps= true;
+            Lex->last_key->period= $3;
           }
         | key_part order_dir
           {

--- a/sql/structs.h
+++ b/sql/structs.h
@@ -159,6 +159,7 @@ typedef struct st_key {
 
   double actual_rec_per_key(uint i);
 
+  bool without_overlaps;
 } KEY;
 
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -1818,7 +1818,17 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
     if (init_period_from_extra2(period, field_pos))
       goto err;
 
-    if (period.name.length + period.constr_name.length + 4*sizeof(uint16)
+    const uchar *key_pos= field_pos + 2 * sizeof(uint16);
+    period.unique_keys= uint2korr(key_pos);
+    for (uint k= 0; k < period.unique_keys; k++)
+    {
+      key_pos+= sizeof(uint16);
+      uint key_nr= uint2korr(key_pos);
+      key_info[key_nr].without_overlaps= true;
+    }
+
+    if (period.name.length + period.constr_name.length
+          + (period.unique_keys + 5) * sizeof(uint16)
         != extra2.application_period.length)
       goto err;
   }

--- a/sql/table.h
+++ b/sql/table.h
@@ -774,6 +774,7 @@ struct TABLE_SHARE
     uint16 end_fieldno;
     Lex_ident name;
     Lex_ident constr_name;
+    uint unique_keys;
     Field *start_field(TABLE_SHARE *s) const
     {
       return s->field[start_fieldno];

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -178,10 +178,11 @@ LEX_CUSTRING build_frm_image(THD *thd, const LEX_CSTRING *table,
   ulong data_offset;
   uint options_len;
   uint gis_extra2_len= 0;
-  size_t period_info_len= create_info->period_info.name
+  size_t period_info_len= create_info->period_info.is_set()
                           ? create_info->period_info.name.length
                             + create_info->period_constr->name.length
-                            + 4 * sizeof(uint16)
+                            + create_info->period_info.unique_keys * sizeof(uint16)
+                            + 5 * sizeof(uint16)
                           : 0;
   uchar fileinfo[FRM_HEADER_SIZE],forminfo[FRM_FORMINFO_SIZE];
   const partition_info *part_info= IF_PARTITIONING(thd->work_part_info, 0);
@@ -375,6 +376,16 @@ LEX_CUSTRING build_frm_image(THD *thd, const LEX_CSTRING *table,
     int2store(pos, get_fieldno_by_name(create_info, create_fields,
                                        create_info->period_info.period.end));
     pos+= sizeof(uint16);
+    int2store(pos, create_info->period_info.unique_keys);
+    pos+= sizeof(uint16);
+    for (uint key= 0; key < keys; key++)
+    {
+      if (key_info[key].without_overlaps)
+      {
+        int2store(pos, key);
+        pos+= sizeof(uint16);
+      }
+    }
   }
 
   if (create_info->versioned())


### PR DESCRIPTION
* The overlaps check is implemented on a handler level per row command. It creates a separate cursor (actually, another handler instance) and caches it inside the original handler, when ha_update_row or ha_insert_row is issued. Cursor closes on unlocking the handler.

* Containing the same key in index means unique constraint violation even in usual terms. So we fetch left and right neighbours and check that they have same key prefix, excluding from the key only the period part. If it doesnt match, then there's no such neighbour, and the check passes. Otherwise, we check if this neighbour intersects with the considered key.

* the check does introduce new error and fails with ER_DUPP_KEY error. This might break REPLACE workflow and should be fixed separately