### PR TITLE
MDEV-18515: The wsrep_cluster_weight status variable is not supported

### DIFF
--- a/mysql-test/include/mtr_check.sql
+++ b/mysql-test/include/mtr_check.sql
@@ -35,7 +35,6 @@ BEGIN
      AND variable_name != 'INNODB_BUFFER_POOL_LOAD_AT_STARTUP'
      AND variable_name not like 'GTID%POS'
      AND variable_name != 'GTID_BINLOG_STATE'
-     AND variable_name != 'AUTO_INCREMENT_INCREMENT'
    ORDER BY variable_name;
 
   -- Dump all databases, there should be none

--- a/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
@@ -9,6 +9,7 @@ innodb-autoinc-lock-mode=2
 default-storage-engine=innodb
 wsrep_gtid_mode=1
 gtid_ignore_duplicates
+auto_increment_increment=3
 
 wsrep-on=1
 wsrep-provider=@ENV.WSREP_PROVIDER

--- a/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
@@ -5,6 +5,7 @@
 binlog-format=row
 innodb-autoinc-lock-mode=2
 default-storage-engine=innodb
+auto_increment_increment=3
 
 wsrep-on=1
 wsrep-provider=@ENV.WSREP_PROVIDER

--- a/mysql-test/suite/galera_3nodes/include/have_mariabackup.inc
+++ b/mysql-test/suite/galera_3nodes/include/have_mariabackup.inc
@@ -1,4 +1,0 @@
-#
-# suite.pm will make sure that all tests including this file
-# will be skipped as needed
-#

--- a/mysql-test/suite/galera_3nodes/r/galera_garbd.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_garbd.result
@@ -1,4 +1,8 @@
+connection node_1;
+connection node_2;
+connection node_3;
 Killing node #3 to free ports for garbd ...
+connection node_3;
 connection node_1;
 Starting garbd ...
 CREATE TABLE t1 (f1 INTEGER);

--- a/mysql-test/suite/galera_3nodes/r/galera_pc_weight.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_pc_weight.result
@@ -1,9 +1,11 @@
 connection node_1;
 SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 3
+1
 SET GLOBAL wsrep_provider_options = 'pc.weight=3';
 SELECT VARIABLE_VALUE = 5 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 5
+1
 SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
 connection node_2;
 SET SESSION wsrep_sync_wait=0;
@@ -14,6 +16,7 @@ Variable_name	Value
 wsrep_cluster_size	2
 SHOW STATUS LIKE 'wsrep_cluster_weight';
 Variable_name	Value
+wsrep_cluster_weight	0
 SHOW STATUS LIKE 'wsrep_cluster_status';
 Variable_name	Value
 wsrep_cluster_status	non-Primary
@@ -38,6 +41,7 @@ Variable_name	Value
 wsrep_cluster_size	2
 SHOW STATUS LIKE 'wsrep_cluster_weight';
 Variable_name	Value
+wsrep_cluster_weight	0
 SHOW STATUS LIKE 'wsrep_cluster_status';
 Variable_name	Value
 wsrep_cluster_status	non-Primary
@@ -56,6 +60,7 @@ wsrep_local_state_comment	Initialized
 connection node_1;
 SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 3
+1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -74,6 +79,7 @@ VARIABLE_VALUE = 'Synced'
 SET GLOBAL wsrep_provider_options = 'pc.weight=1';
 SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 1
+1
 connection node_1;
 SET GLOBAL wsrep_provider_options = 'gmcast.isolate=0';
 connection node_2;
@@ -84,6 +90,7 @@ VARIABLE_VALUE = 3
 1
 SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 3
+1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -105,6 +112,7 @@ VARIABLE_VALUE = 3
 1
 SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 3
+1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -126,6 +134,7 @@ VARIABLE_VALUE = 3
 1
 SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_weight';
 VARIABLE_VALUE = 3
+1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1

--- a/mysql-test/suite/galera_3nodes/r/galera_var_dirty_reads2.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_var_dirty_reads2.result
@@ -1,3 +1,7 @@
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER);
 INSERT INTO t1 VALUES (1);
 connection node_2;

--- a/mysql-test/suite/galera_3nodes/suite.pm
+++ b/mysql-test/suite/galera_3nodes/suite.pm
@@ -50,9 +50,12 @@ push @::global_suppressions,
      qr(WSREP: There are no nodes in the same segment that will ever be able to become donors, yet there is a suitable donor outside. Will use that one.),
      qr(WSREP: evs::proto.*),
      qr|WSREP: Ignoring possible split-brain \(allowed by configuration\) from view:.*|,
+     qr(WSREP: no nodes coming from prim view, prim not possible),
      qr(WSREP: Member .* requested state transfer from .* but it is impossible to select State Transfer donor: Resource temporarily unavailable),
+     qr(WSREP: user message in state LEAVING),
      qr(WSREP: .* sending install message failed: Transport endpoint is not connected),
      qr(WSREP: .* sending install message failed: Resource temporarily unavailable),
+     qr(WSREP: Sending JOIN failed: -107 \(Transport endpoint is not connected\). Will retry in new primary component.),
      qr(WSREP: Could not find peer:),
      qr|WSREP: gcs_caused\(\) returned .*|,
      qr|WSREP: Protocol violation. JOIN message sender .* is not in state transfer \(SYNCED\). Message ignored.|,
@@ -78,11 +81,11 @@ sub skip_combinations {
   my %skip = ();
   $skip{'include/have_filekeymanagement.inc'} = 'needs file_key_management plugin'
              unless $ENV{FILE_KEY_MANAGEMENT_SO};
-  $skip{'include/have_mariabackup.inc'} = 'Need mariabackup'
+  $skip{'suite/galera/include/have_mariabackup.inc'} = 'Need mariabackup'
              unless which(mariabackup);
-  $skip{'include/have_mariabackup.inc'} = 'Need ss'
+  $skip{'suite/galera/include/have_mariabackup.inc'} = 'Need ss'
              unless which(ss);
-  $skip{'include/have_mariabackup.inc'} = 'Need socat or nc'
+  $skip{'suite/galera/include/have_mariabackup.inc'} = 'Need socat or nc'
              unless $ENV{MTR_GALERA_TFMT};
   %skip;
 }

--- a/mysql-test/suite/galera_3nodes/t/galera_garbd.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_garbd.test
@@ -7,10 +7,18 @@
 --source include/have_innodb.inc
 --source include/big_test.inc
 
---echo Killing node #3 to free ports for garbd ...
 --let $galera_connection_name = node_3
 --let $galera_server_number = 3
 --source include/galera_connect.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--echo Killing node #3 to free ports for garbd ...
+--connection node_3
 --let $gp3 = `SELECT SUBSTR(@@wsrep_provider_options, LOCATE('base_port =', @@wsrep_provider_options) + LENGTH('base_port = '))`
 --let $galera_port_3 = `SELECT SUBSTR('$gp3', 1, LOCATE(';', '$gp3') - 1)`
 --source include/shutdown_mysqld.inc
@@ -55,6 +63,8 @@ DROP TABLE t1;
 --connection node_3
 --source include/start_mysqld.inc
 
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc
 
 # Workaround for galera#101
 

--- a/mysql-test/suite/galera_3nodes/t/galera_innobackupex_backup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_innobackupex_backup.test
@@ -4,7 +4,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
---source include/have_mariabackup.inc
+--source suite/galera/include/have_mariabackup.inc
 
 --let $galera_connection_name = node_3
 --let $galera_server_number = 3

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.test
@@ -1,6 +1,6 @@
 --source include/galera_cluster.inc
 --source include/check_ipv6.inc
---source include/have_mariabackup.inc
+--source suite/galera/include/have_mariabackup.inc
 
 # Confirm that initial handshake happened over ipv6
 

--- a/mysql-test/suite/galera_3nodes/t/galera_var_dirty_reads2.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_var_dirty_reads2.test
@@ -5,6 +5,17 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
 CREATE TABLE t1 (f1 INTEGER);
 INSERT INTO t1 VALUES (1);
 
@@ -110,3 +121,6 @@ SET GLOBAL wsrep_provider_options='gmcast.isolate=0';
 --source include/wait_condition.inc
 
 DROP TABLE t1;
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -516,7 +516,7 @@ kill_xtrabackup()
 setup_ports()
 {
     if [[ "$WSREP_SST_OPT_ROLE"  == "donor" ]];then
-        if [[ ${WSREP_SST_OPT_ADDR:0:1} == '[' ]];then
+        if [ "${WSREP_SST_OPT_ADDR#\[}" != "$WSREP_SST_OPT_ADDR" ]; then
             remain=$(echo $WSREP_SST_OPT_ADDR | awk -F '\\][:/]' '{ print $2 }')
             REMOTEIP=$(echo $WSREP_SST_OPT_ADDR | awk -F '\\]:' '{ print $1 }')"]"
             SST_PORT=$(echo $remain | awk -F '[:/]' '{ print $1 }')
@@ -529,7 +529,7 @@ setup_ports()
             sst_ver=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $5 }')
         fi
     else
-        if [[ ${WSREP_SST_OPT_ADDR:0:1} == '[' ]];then
+        if [ "${WSREP_SST_OPT_ADDR#\[}" != "$WSREP_SST_OPT_ADDR" ]; then
             SST_PORT=$(echo ${WSREP_SST_OPT_ADDR} | awk -F '\\]:' '{ print $2 }')
         else
             SST_PORT=$(echo ${WSREP_SST_OPT_ADDR} | awk -F ':' '{ print $2 }')
@@ -972,7 +972,7 @@ then
     if [ -z "${SST_PORT}" ]
     then
         SST_PORT=4444
-        if [[ ${ADDR:0:1} == '[' ]];then
+        if [ "${ADDR#\[}" != "$ADDR" ]; then
             ADDR="$(echo ${WSREP_SST_OPT_ADDR} | awk -F '\\]:' '{ print $1 }')]:${SST_PORT}"
         else
             ADDR="$(echo ${WSREP_SST_OPT_ADDR} | awk -F ':' '{ print $1 }'):${SST_PORT}"

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -398,7 +398,7 @@ then
     rm -rf "$RSYNC_PID"
 
     ADDR=$WSREP_SST_OPT_ADDR
-    if [[ ${ADDR:0:1} == '[' ]]; then
+    if [ "${ADDR#\[}" != "$ADDR" ]; then
         RSYNC_PORT=$(echo $ADDR | awk -F '\\]:' '{ print $2 }')
         RSYNC_ADDR=$(echo $ADDR | awk -F '\\]:' '{ print $1 }')"]"
     else


### PR DESCRIPTION
Current version of Galera does not support the wsrep_cluster_weight
status variable, which causes the galera_pc_weight test (from the
galera_3nodes suite) to fail.

This patch adds the missing variable to the wsrep status variables.

This patch also contains improvements for other tests, which taken
from the 10.2 branch. This changes synchronize the 10.3 branch with
the latest version of the previous MDEV-18426 fixes, which are also
related to the galera_3nodes suite (which originally were made for
the 10.2 branch, and has not yet been transferred to 10.3).

https://jira.mariadb.org/browse/MDEV-18515