### PR TITLE
Assertion `old_part_id == m_last_part' failed in ha_partition::update…

### DIFF
--- a/mysql-test/main/partition_alter.result
+++ b/mysql-test/main/partition_alter.result
@@ -129,3 +129,26 @@ ERROR HY000: Duplicate partition name p1
 alter table t1 add partition (partition p1);
 ERROR HY000: Duplicate partition name p1
 drop table t1;
+#
+# MDEV-17091 Assertion `old_part_id == m_last_part' failed in
+# ha_partition::update_row or `part_id == m_last_part' in
+# ha_partition::delete_row upon UPDATE/DELETE after dropping versioning
+#
+create or replace table t1 (pk int, f int, primary key(pk, f)) engine=innodb
+partition by key() partitions 2;
+insert into t1 values (1,10),(2,11);
+# expected to hit same partition
+select * from t1 partition (p0);
+pk	f
+1	10
+2	11
+alter table t1 drop primary key, drop f, add primary key(pk);
+# 1 and 2 are expected to be in different partitions
+select * from t1 partition(p0);
+pk
+1
+select * from t1 partition(p1);
+pk
+2
+delete from t1;
+drop table t1;

--- a/mysql-test/main/partition_alter.test
+++ b/mysql-test/main/partition_alter.test
@@ -125,3 +125,22 @@ alter table t1 add partition (partition p1);
 --error ER_SAME_NAME_PARTITION
 alter table t1 add partition (partition p1);
 drop table t1;
+
+--echo #
+--echo # MDEV-17091 Assertion `old_part_id == m_last_part' failed in
+--echo # ha_partition::update_row or `part_id == m_last_part' in
+--echo # ha_partition::delete_row upon UPDATE/DELETE after dropping versioning
+--echo #
+create or replace table t1 (pk int, f int, primary key(pk, f)) engine=innodb
+        partition by key() partitions 2;
+
+insert into t1 values (1,10),(2,11);
+--echo # expected to hit same partition
+select * from t1 partition (p0);
+
+alter table t1 drop primary key, drop f, add primary key(pk);
+--echo # 1 and 2 are expected to be in different partitions
+select * from t1 partition(p0);
+select * from t1 partition(p1);
+delete from t1;
+drop table t1;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -528,6 +528,30 @@ Warning	1906	The value specified for generated column 'v' in table 't1' ignored
 create or replace table t1 (i int) with system versioning partition by system_time limit 10 (partition p0 history, partition pn current);
 select * from t1 partition (p0) for system_time all;
 ERROR HY000: SYSTEM_TIME partitions in table `t1` does not support historical query
+#
+# MDEV-17091 Assertion `old_part_id == m_last_part' failed in
+# ha_partition::update_row or `part_id == m_last_part' in
+# ha_partition::delete_row upon UPDATE/DELETE after dropping versioning
+#
+create or replace table t1 (pk int primary key, f int) engine=innodb
+with system versioning
+partition by key() partitions 2;
+insert into t1 values (1,10),(2,20);
+# expected to hit same partition
+select * from t1 partition (p0);
+pk	f
+1	10
+2	20
+alter table t1 drop system versioning;
+# 1 and 2 are expected to be in different partitions
+select * from t1 partition(p0);
+pk	f
+1	10
+select * from t1 partition(p1);
+pk	f
+2	20
+update t1 set f=pk;
+drop table t1;
 # Test cleanup
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -481,6 +481,26 @@ create or replace table t1 (i int) with system versioning partition by system_ti
 --error ER_VERS_QUERY_IN_PARTITION
 select * from t1 partition (p0) for system_time all;
 
+--echo #
+--echo # MDEV-17091 Assertion `old_part_id == m_last_part' failed in
+--echo # ha_partition::update_row or `part_id == m_last_part' in
+--echo # ha_partition::delete_row upon UPDATE/DELETE after dropping versioning
+--echo #
+create or replace table t1 (pk int primary key, f int) engine=innodb
+        with system versioning
+        partition by key() partitions 2;
+insert into t1 values (1,10),(2,20);
+--echo # expected to hit same partition
+select * from t1 partition (p0);
+alter table t1 drop system versioning;
+
+--echo # 1 and 2 are expected to be in different partitions
+select * from t1 partition(p0);
+select * from t1 partition(p1);
+
+update t1 set f=pk;
+drop table t1;
+
 --echo # Test cleanup
 drop database test;
 create database test;

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -5929,6 +5929,32 @@ the generated partition syntax in a correct manner.
           *partition_changed= true;
         }
       }
+
+      // In case of PARTITION BY KEY(), check if primary key has changed
+      // System versioning also implicitly adds/removes primary key parts
+      if (alter_info->partition_flags == 0 && part_info->list_of_part_fields
+          && part_info->part_field_list.elements == 0 && !*partition_changed)
+      {
+        if (alter_info->flags & (ALTER_DROP_SYSTEM_VERSIONING
+                                 | ALTER_ADD_SYSTEM_VERSIONING))
+        {
+          *partition_changed= true;
+        }
+        else
+        {
+          List_iterator<Key> it(alter_info->key_list);
+          Key *key;
+          while((key= it++))
+          {
+            if (key->type == Key::PRIMARY)
+            {
+              *partition_changed= true;
+              break;
+            }
+          }
+
+        }
+      }
       /*
         Set up partition default_engine_type either from the create_info
         or from the previus table

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -5932,8 +5932,8 @@ the generated partition syntax in a correct manner.
 
       // In case of PARTITION BY KEY(), check if primary key has changed
       // System versioning also implicitly adds/removes primary key parts
-      if (alter_info->partition_flags == 0 && part_info->list_of_part_fields
-          && part_info->part_field_list.elements == 0 && !*partition_changed)
+      if (alter_info->partition_flags == 0 && part_info->list_of_part_fields &&
+          part_info->part_field_list.elements == 0 && !*partition_changed)
       {
         if (alter_info->flags & (ALTER_DROP_SYSTEM_VERSIONING
                                  | ALTER_ADD_SYSTEM_VERSIONING))


### PR DESCRIPTION
…_row or `part_id == m_last_part' in ha_partition::delete_row upon UPDATE/DELETE after dropping versioning

PRIMARY KEY change hadn't been treated as partition reorganization in case of partitioning by KEY() (without parameters).

* set `*partition_changed= true` in the described case.
* since add/drop system versioning does not affect alter_info->key_list, it required separate attention