### PR TITLE
post-RC app-periods fixes

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -200,6 +200,7 @@ my @DEFAULT_SUITES= qw(
     unit-
     vcol-
     versioning-
+    period-
     wsrep-
     galera-
   );

--- a/mysql-test/suite/period/r/delete.result
+++ b/mysql-test/suite/period/r/delete.result
@@ -291,7 +291,7 @@ ERROR 42S02: 'v' is a view
 # View can't be used
 create or replace view v as select t.* from t, t as t1;
 delete from v for portion of p from '2000-01-01' to '2018-01-01';
-ERROR 42S02: 'v' is a view
+ERROR HY000: Can not delete from join view 'test.v'
 # auto_increment field overflow
 create or replace table t (id tinyint auto_increment primary key,
 s date, e date, period for apptime(s,e));

--- a/mysql-test/suite/period/t/delete.test
+++ b/mysql-test/suite/period/t/delete.test
@@ -133,7 +133,7 @@ delete from v for portion of p from '2000-01-01' to '2018-01-01';
 
 --echo # View can't be used
 create or replace view v as select t.* from t, t as t1;
---error ER_IT_IS_A_VIEW
+--error ER_VIEW_DELETE_MERGE_VIEW
 delete from v for portion of p from '2000-01-01' to '2018-01-01';
 
 --echo # auto_increment field overflow

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -718,9 +718,14 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     goto got_error;
 
   if (table_list->has_period())
+  {
     table->use_all_columns();
+    table->rpl_write_set= table->write_set;
+  }
   else
+  {
     table->mark_columns_needed_for_delete();
+  }
 
   if ((table->file->ha_table_flags() & HA_CAN_FORCE_BULK_DELETE) &&
       !table->prepare_triggers_for_delete_stmt_or_event())

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -380,18 +380,6 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
       table_list->on_expr= NULL;
     }
   }
-  if (table_list->has_period())
-  {
-    if (table_list->is_view_or_derived())
-    {
-      my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
-      DBUG_RETURN(true);
-    }
-
-    conds= select_lex->period_setup_conds(thd, table_list, conds);
-    if (!conds)
-      DBUG_RETURN(true);
-  }
 
   if (mysql_handle_list_of_derived(thd->lex, table_list, DT_MERGE_FOR_INSERT))
     DBUG_RETURN(TRUE);
@@ -1055,6 +1043,20 @@ int mysql_prepare_delete(THD *thd, TABLE_LIST *table_list,
     if (select_lex->vers_setup_conds(thd, table_list))
       DBUG_RETURN(true);
   }
+
+  if (table_list->has_period())
+  {
+    if (table_list->is_view_or_derived())
+    {
+      my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
+      DBUG_RETURN(true);
+    }
+
+    *conds= select_lex->period_setup_conds(thd, table_list, *conds);
+    if (!*conds)
+      DBUG_RETURN(true);
+  }
+
   if ((wild_num && setup_wild(thd, table_list, field_list, NULL, wild_num,
                               &select_lex->hidden_bit_fields)) ||
       setup_fields(thd, Ref_ptr_array(),

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -433,6 +433,16 @@ int mysql_update(THD *thd,
   if (mysql_prepare_update(thd, table_list, &conds, order_num, order))
     DBUG_RETURN(1);
 
+  if (table_list->has_period())
+  {
+    if (!table_list->period_conditions.start.item->const_item()
+        || !table_list->period_conditions.end.item->const_item())
+    {
+      my_error(ER_NOT_CONSTANT_EXPRESSION, MYF(0), "FOR PORTION OF");
+      DBUG_RETURN(true);
+    }
+  }
+
   old_covering_keys= table->covering_keys;		// Keys used in WHERE
   /* Check the fields we are going to modify */
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
@@ -1368,15 +1378,6 @@ bool mysql_prepare_update(THD *thd, TABLE_LIST *table_list,
       setup_ftfuncs(select_lex))
     DBUG_RETURN(TRUE);
 
-  if (table_list->has_period())
-  {
-    if (!table_list->period_conditions.start.item->const_item()
-        || !table_list->period_conditions.end.item->const_item())
-    {
-      my_error(ER_NOT_CONSTANT_EXPRESSION, MYF(0), "FOR PORTION OF");
-      DBUG_RETURN(true);
-    }
-  }
 
   select_lex->fix_prepare_information(thd, conds, &fake_conds);
   DBUG_RETURN(FALSE);
@@ -1666,6 +1667,17 @@ int mysql_multi_update_prepare(THD *thd)
 
   if (mysql_handle_derived(lex, DT_PREPARE))
     DBUG_RETURN(TRUE);
+
+  if (table_list->has_period())
+  {
+    /*
+      Multi-table update is not supported on syntax lexel. However it's possible
+      to get here through PREPARE with update of multi-table view.
+     */
+    DBUG_ASSERT(table_list->is_view_or_derived());
+    my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
+    DBUG_RETURN(TRUE);
+  }
 
   if (setup_tables_and_check_access(thd,
                                     &lex->first_select_lex()->context,


### PR DESCRIPTION
Here are two commits, fixing three bugs. They're quite small, so have put it in one PR.

In short:
* MDEV-18853 Assertion `0' failed in Protocol::end_statement upon DELETE .. FOR PORTION via prepared statement
  Query arena was not taken into account
* MDEV-18852 Server crashes in reinit_stmt_before_use upon UPDATE .. FOR PORTION via prepared statement
  Additionally fix incorrect `DBUG_RETURN(NULL)` in `period_setup_conds`;
* MDEV-18859 Server crashes in bitmap_bits_set / pack_row / THD::binlog_write_row upon DELETE .. FOR PORTION with binary logging
  `table->rpl_write_set` was NULL