### PR TITLE
MDEV-18921 Server crashes in bitmap_bits_set or bitmap_is_set upon UPDATE IGNORE .. FOR PORTION with binary logging

### DIFF
--- a/mysql-test/suite/period/t/delete.test
+++ b/mysql-test/suite/period/t/delete.test
@@ -1,4 +1,5 @@
 source suite/period/engines.inc;
+source include/have_log_bin.inc
 
 create or replace table t (id int, s date, e date, period for apptime(s,e));
 

--- a/mysql-test/suite/period/t/update.test
+++ b/mysql-test/suite/period/t/update.test
@@ -1,4 +1,5 @@
 source suite/period/engines.inc;
+source include/have_log_bin.inc
 
 create or replace table t (id int, s date, e date, period for apptime(s,e));
 
@@ -149,5 +150,11 @@ select * from t;
 update t for portion of apptime from '2000-01-01' to '2018-01-01' set x= x + 5;
 --sorted_result
 select *, xs=s and xe=e from t;
+
+--echo # MDEV-18921 Server crashes in bitmap_bits_set or bitmap_is_set upon
+--echo # UPDATE IGNORE .. FOR PORTION with binary logging
+create or replace table t1 (f int, s date, e date, period for app(s,e));
+insert into t1 values (1,'2016-09-21','2019-06-14');
+update ignore t1 for portion of app from '2019-03-13' to '2019-03-14' set f = 1;
 
 create or replace database test;

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -569,9 +569,14 @@ int mysql_update(THD *thd,
     goto err;
 
   if (table_list->has_period())
+  {
     table->use_all_columns();
+    table->rpl_write_set= table->write_set;
+  }
   else
+  {
     table->mark_columns_needed_for_update();
+  }
 
   table->update_const_key_parts(conds);
   order= simple_remove_const(order, conds);


### PR DESCRIPTION
The fix is same as for MDEV-18859: initialize table->rpl_write_set in FOR PORTION OF case.

Add have_binlog.inc for both tests