### PR TITLE
MDEV-18865 Assertion `t->first->versioned_by_id()' failed in innodb_p…

### DIFF
--- a/mysql-test/suite/versioning/r/trx_id.result
+++ b/mysql-test/suite/versioning/r/trx_id.result
@@ -470,4 +470,13 @@ add column row_end bigint unsigned as row end,
 add period for system_time(row_start,row_end),
 with system versioning;
 set autocommit= 1;
+# MDEV-18865 Assertion `t->first->versioned_by_id()'
+# failed in innodb_prepare_commit_versioned
+create or replace table t (x int) engine=innodb;
+insert into t values (0);
+alter table t add `row_start` bigint unsigned as row start,
+add `row_end` bigint unsigned as row end,
+add period for system_time(`row_start`,`row_end`),
+modify x int after row_start,
+with system versioning;
 create or replace database test;

--- a/mysql-test/suite/versioning/t/trx_id.test
+++ b/mysql-test/suite/versioning/t/trx_id.test
@@ -482,4 +482,16 @@ alter table t
   with system versioning;
 set autocommit= 1;
 
+--echo # MDEV-18865 Assertion `t->first->versioned_by_id()'
+--echo # failed in innodb_prepare_commit_versioned
+
+create or replace table t (x int) engine=innodb;
+insert into t values (0);
+alter table t add `row_start` bigint unsigned as row start,
+              add `row_end` bigint unsigned as row end,
+              add period for system_time(`row_start`,`row_end`),
+              modify x int after row_start,
+              with system versioning;
+
+
 create or replace database test;

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -1555,7 +1555,7 @@ struct dict_table_t {
 	bool versioned() const { return vers_start || vers_end; }
 	bool versioned_by_id() const
 	{
-		return vers_start && cols[vers_start].mtype == DATA_INT;
+		return versioned() && cols[vers_start].mtype == DATA_INT;
 	}
 
 	void inc_fk_checks()


### PR DESCRIPTION
…repare_commit_versioned

Cause:
* row_start != 0 treated as it exists. Probably, possible row permutations had not been taken in mind.

Solution:
* Checking both row_start and row_end is correct, so versioned() function is used